### PR TITLE
Symlink to file:// repos by adding ?symlink suffix

### DIFF
--- a/src/download.hpp
+++ b/src/download.hpp
@@ -64,6 +64,8 @@ protected:
   virtual std::ostream *openStream() = 0;
   virtual void closeStream() {}
 
+  std::string m_url;
+
 private:
   struct WriteContext {
     std::ostream *stream;
@@ -77,7 +79,6 @@ private:
   static size_t WriteData(char *, size_t, size_t, void *);
   static int UpdateProgress(void *, double, double, double, double);
 
-  std::string m_url;
   std::string m_expectedChecksum;
   NetworkOpts m_opts;
   int m_flags;
@@ -105,12 +106,31 @@ public:
   bool save();
 
 protected:
+  TempPath m_path;
+};
+
+class CopyFileDownload : public FileDownload {
+public:
+  CopyFileDownload(const Path &target, const std::string &url,
+    const NetworkOpts &, int flags = 0);
+
+protected:
   std::ostream *openStream() override;
   void closeStream() override;
 
 private:
-  TempPath m_path;
   std::ofstream m_stream;
+};
+
+class SymlinkFileDownload : public FileDownload {
+public:
+  SymlinkFileDownload(const Path &target, const std::string &url,
+    const NetworkOpts &, int flags = 0);
+
+  bool run() override;
+
+protected:
+  std::ostream *openStream() override;
 };
 
 #endif

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -106,6 +106,20 @@ bool FS::rename(const Path &from, const Path &to)
   return !func(nativePath(from).c_str(), nativePath(to).c_str());
 }
 
+bool FS::symlink(const Path &target, const Path &link)
+{
+  mkdir(link.dirname());
+
+  const auto &nativeTarget = nativePath(target);
+  const auto &nativeLink = nativePath(link);
+
+#ifdef _WIN32
+  return CreateSymbolicLink(nativeLink.c_str(), nativeTarget.c_str(), 0x0);
+#else
+  return !::symlink(nativeTarget.c_str(), nativeLink.c_str());
+#endif
+}
+
 bool FS::remove(const Path &path)
 {
   const auto &fullPath = nativePath(path);

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -31,6 +31,7 @@ namespace FS {
   bool write(const Path &, const std::string &);
   bool rename(const TempPath &);
   bool rename(const Path &, const Path &);
+  bool symlink(const Path &, const Path &);
   bool remove(const Path &);
   bool removeRecursive(const Path &);
   bool mtime(const Path &, time_t *);

--- a/src/index_v1.cpp
+++ b/src/index_v1.cpp
@@ -24,7 +24,7 @@
 
 static void LoadMetadataV1(XmlNode , Metadata *);
 static void LoadCategoryV1(XmlNode , Index *);
-static void LoadPackageV1(XmlNode , Category *);
+static void LoadPackageV1(XmlNode , Category *, Index *);
 static void LoadVersionV1(XmlNode , Package *);
 static void LoadSourceV1(XmlNode , Version *);
 
@@ -75,18 +75,18 @@ void LoadCategoryV1(XmlNode catNode, Index *ri)
 
   for(XmlNode packNode = catNode.firstChild("reapack");
       packNode; packNode = packNode.nextSibling("reapack"))
-    LoadPackageV1(packNode, cat);
+    LoadPackageV1(packNode, cat, ri);
 
   if(ri->addCategory(cat))
     ptr.release();
 }
 
-void LoadPackageV1(XmlNode packNode, Category *cat)
+void LoadPackageV1(XmlNode packNode, Category *cat, Index *ri)
 {
   const XmlString &type = packNode.attribute("type"),
                   &name = packNode.attribute("name");
 
-  Package *pack = new Package(Package::getType(type.value_or("")), name.value_or(""), cat);
+  Package *pack = new Package(Package::getType(type.value_or("")), name.value_or(""), cat, ri->name());
   std::unique_ptr<Package> ptr(pack);
 
   if(const XmlString &desc = packNode.attribute("desc"))

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -84,8 +84,8 @@ const std::string &Package::displayName(const std::string &name, const std::stri
   return desc.empty() ? name : desc;
 }
 
-Package::Package(const Type type, const std::string &name, const Category *cat)
-  : m_category(cat), m_type(type), m_name(name)
+Package::Package(const Type type, const std::string &name, const Category *cat, const std::string &remote)
+  : m_category(cat), m_type(type), m_name(name), m_remote(remote)
 {
   if(m_name.empty())
     throw reapack_error("empty package name");

--- a/src/package.hpp
+++ b/src/package.hpp
@@ -44,13 +44,14 @@ public:
   static const char *displayType(Type);
   static const std::string &displayName(const std::string &name, const std::string &desc);
 
-  Package(const Type, const std::string &name, const Category *);
+  Package(const Type, const std::string &name, const Category *, const std::string &remote);
   ~Package();
 
   const Category *category() const { return m_category; }
   Type type() const { return m_type; }
   std::string displayType() const { return displayType(m_type); }
   const std::string &name() const { return m_name; }
+  const std::string &remote() const { return m_remote; }
   std::string fullName() const;
   void setDescription(const std::string &d) { m_desc = d; }
   const std::string &description() const { return m_desc; }
@@ -80,6 +81,7 @@ private:
   Type m_type;
   std::string m_name;
   std::string m_desc;
+  std::string m_remote;
   Metadata m_metadata;
   std::set<const Version *, CompareVersion> m_versions;
 

--- a/src/reapack.cpp
+++ b/src/reapack.cpp
@@ -382,7 +382,7 @@ void ReaPack::registerSelf()
   // hard-coding galore!
   Index ri("ReaPack");
   Category cat("Extensions", &ri);
-  Package pkg(Package::ExtensionType, "ReaPack.ext", &cat);
+  Package pkg(Package::ExtensionType, "ReaPack.ext", &cat, "ReaPack");
   Version ver(REAPACK_VERSION, &pkg);
   ver.setAuthor("cfillion");
   ver.addSource(new Source(REAPACK_FILENAME, "dummy url", &ver));

--- a/src/synchronize.cpp
+++ b/src/synchronize.cpp
@@ -42,7 +42,7 @@ bool SynchronizeTask::start()
   if(!m_stale && mtime && (!threshold || mtime > now - threshold))
     return true;
 
-  auto dl = new FileDownload(m_indexPath, m_remote.url(),
+  auto dl = new CopyFileDownload(m_indexPath, m_remote.url(),
     netConfig, Download::NoCacheFlag);
   dl->setName(m_remote.name());
 

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -94,6 +94,7 @@ private:
   int m_flags;
   Registry::Entry m_oldEntry;
   ArchiveReaderPtr m_reader;
+  bool m_symlink;
 
   bool m_fail;
   IndexPtr m_index; // keep in memory

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -89,7 +89,7 @@ TEST_CASE("future version", M) {
 TEST_CASE("add a category", M) {
   Index ri("a");
   Category *cat = new Category("a", &ri);
-  Package *pack = new Package(Package::ScriptType, "name", cat);
+  Package *pack = new Package(Package::ScriptType, "name", cat, "remote");
   Version *ver = new Version("1", pack);
   Source *source = new Source({}, "google.com", ver);
 
@@ -134,7 +134,7 @@ TEST_CASE("drop empty category", M) {
 TEST_CASE("add a package", M) {
   Index ri("a");
   Category cat("a", &ri);
-  Package *pack = new Package(Package::ScriptType, "name", &cat);
+  Package *pack = new Package(Package::ScriptType, "name", &cat, "remote");
   Version *ver = new Version("1", pack);
   ver->addSource(new Source({}, "google.com", ver));
   pack->addVersion(ver);
@@ -151,7 +151,7 @@ TEST_CASE("add a package", M) {
 
 TEST_CASE("add owned package", M) {
   Category cat1("a", nullptr);
-  Package *pack = new Package(Package::ScriptType, "name", &cat1);
+  Package *pack = new Package(Package::ScriptType, "name", &cat1, "remote");
 
   try {
     Category cat2("b", nullptr);
@@ -166,14 +166,14 @@ TEST_CASE("add owned package", M) {
 
 TEST_CASE("drop empty package", M) {
   Category cat("a", nullptr);
-  const Package pkg(Package::ScriptType, "name", &cat);
+  const Package pkg(Package::ScriptType, "name", &cat, "remote");
   REQUIRE_FALSE(cat.addPackage(&pkg));
   REQUIRE(cat.packages().empty());
 }
 
 TEST_CASE("drop unknown package", M) {
   Category cat("a", nullptr);
-  const Package pkg(Package::UnknownType, "name", &cat);
+  const Package pkg(Package::UnknownType, "name", &cat, "remote");
   REQUIRE_FALSE(cat.addPackage(&pkg));
   REQUIRE(cat.packages().size() == 0);
 }
@@ -217,7 +217,7 @@ TEST_CASE("set index name", M) {
 TEST_CASE("find package", M) {
   Index ri("index name");
   Category *cat = new Category("cat", &ri);
-  Package *pack = new Package(Package::ScriptType, "pkg", cat);
+  Package *pack = new Package(Package::ScriptType, "pkg", cat, "remote");
   Version *ver = new Version("1", pack);
   Source *source = new Source({}, "google.com", ver);
 

--- a/test/package.cpp
+++ b/test/package.cpp
@@ -50,7 +50,7 @@ TEST_CASE("package type to string", M) {
 TEST_CASE("invalid package name", M) {
   SECTION("empty") {
     try {
-      Package pack(Package::ScriptType, {}, nullptr);
+      Package pack(Package::ScriptType, {}, nullptr, "remote");
       FAIL();
     }
     catch(const reapack_error &e) {
@@ -60,7 +60,7 @@ TEST_CASE("invalid package name", M) {
 
   SECTION("slash") {
     try {
-      Package pack(Package::ScriptType, "hello/world", nullptr);
+      Package pack(Package::ScriptType, "hello/world", nullptr, "remote");
       FAIL();
     }
     catch(const reapack_error &e) {
@@ -70,7 +70,7 @@ TEST_CASE("invalid package name", M) {
 
   SECTION("backslash") {
     try {
-      Package pack(Package::ScriptType, "hello\\world", nullptr);
+      Package pack(Package::ScriptType, "hello\\world", nullptr, "remote");
       FAIL();
     }
     catch(const reapack_error &e) {
@@ -83,7 +83,7 @@ TEST_CASE("package versions are sorted", M) {
   Index ri("Remote Name");
   Category cat("Category Name", &ri);
 
-  Package pack(Package::ScriptType, "a", &cat);
+  Package pack(Package::ScriptType, "a", &cat, "remote");
   CHECK(pack.versions().size() == 0);
 
   Version *final = new Version("1", &pack);
@@ -107,7 +107,7 @@ TEST_CASE("package versions are sorted", M) {
 TEST_CASE("get latest stable version", M) {
   Index ri("Remote Name");
   Category cat("Category Name", &ri);
-  Package pack(Package::ScriptType, "a", &cat);
+  Package pack(Package::ScriptType, "a", &cat, "remote");
 
   Version *alpha = new Version("2.0-alpha", &pack);
   alpha->addSource(new Source({}, "google.com", alpha));
@@ -131,7 +131,7 @@ TEST_CASE("get latest stable version", M) {
 TEST_CASE("pre-release updates", M) {
   Index ri("Remote Name");
   Category cat("Category Name", &ri);
-  Package pack(Package::ScriptType, "a", &cat);
+  Package pack(Package::ScriptType, "a", &cat, "remote");
 
   Version *stable1 = new Version("0.9", &pack);
   stable1->addSource(new Source({}, "google.com", stable1));
@@ -166,7 +166,7 @@ TEST_CASE("pre-release updates", M) {
 }
 
 TEST_CASE("drop empty version", M) {
-  Package pack(Package::ScriptType, "a", nullptr);
+  Package pack(Package::ScriptType, "a", nullptr, "remote");
   const Version ver("1", &pack);
   REQUIRE_FALSE(pack.addVersion(&ver));
   REQUIRE(pack.versions().empty());
@@ -174,8 +174,8 @@ TEST_CASE("drop empty version", M) {
 }
 
 TEST_CASE("add owned version", M) {
-  Package pack1(Package::ScriptType, "a", nullptr);
-  Package pack2(Package::ScriptType, "a", nullptr);
+  Package pack1(Package::ScriptType, "a", nullptr, "remote");
+  Package pack2(Package::ScriptType, "a", nullptr, "remote");
 
   Version *ver = new Version("1", &pack1);
 
@@ -192,7 +192,7 @@ TEST_CASE("add owned version", M) {
 TEST_CASE("add duplicate version", M) {
   Index ri("r");
   Category cat("c", &ri);
-  Package pack(Package::ScriptType, "p", &cat);
+  Package pack(Package::ScriptType, "p", &cat, "remote");
 
   Version *ver = new Version("1", &pack);
   ver->addSource(new Source({}, "google.com", ver));
@@ -211,7 +211,7 @@ TEST_CASE("find matching version", M) {
   Index ri("Remote Name");
   Category cat("Category Name", &ri);
 
-  Package pack(Package::ScriptType, "a", &cat);
+  Package pack(Package::ScriptType, "a", &cat, "remote");
   CHECK(pack.versions().size() == 0);
 
   Version *ver = new Version("1", &pack);
@@ -229,7 +229,7 @@ TEST_CASE("find matching version", M) {
 TEST_CASE("package full name", M) {
   const Index ri("Index Name");
   const Category cat("Category Name", &ri);
-  Package pack(Package::ScriptType, "file.name", &cat);
+  Package pack(Package::ScriptType, "file.name", &cat, "remote");
 
   REQUIRE(pack.fullName() == "Index Name/Category Name/file.name");
 
@@ -238,7 +238,7 @@ TEST_CASE("package full name", M) {
 }
 
 TEST_CASE("package description", M) {
-  Package pack(Package::ScriptType, "test.lua", nullptr);
+  Package pack(Package::ScriptType, "test.lua", nullptr, "remote");
   REQUIRE(pack.description().empty());
 
   pack.setDescription("hello world");
@@ -246,7 +246,7 @@ TEST_CASE("package description", M) {
 }
 
 TEST_CASE("package display name", M) {
-  Package pack(Package::ScriptType, "test.lua", nullptr);
+  Package pack(Package::ScriptType, "test.lua", nullptr, "remote");
   REQUIRE(pack.displayName() == "test.lua");
 
   pack.setDescription("hello world");

--- a/test/receipt.cpp
+++ b/test/receipt.cpp
@@ -16,7 +16,7 @@ TEST_CASE("non-empty receipt", M) {
   SECTION("install") {
     IndexPtr ri = std::make_shared<Index>("Index Name");
     Category cat("Category Name", ri.get());
-    Package pkg(Package::ScriptType, "Package Name", &cat);
+    Package pkg(Package::ScriptType, "Package Name", &cat, "remote");
     Version ver("1.0", &pkg);
     r.addInstall(&ver, {});
   }
@@ -41,7 +41,7 @@ TEST_CASE("set receipt flags", M) {
   SECTION("install") {
     IndexPtr ri = std::make_shared<Index>("Index Name");
     Category cat("Category Name", ri.get());
-    Package pkg(Package::ScriptType, "Package Name", &cat);
+    Package pkg(Package::ScriptType, "Package Name", &cat, "remote");
     Version ver("1.0", &pkg);
     r.addInstall(&ver, {});
 
@@ -77,8 +77,8 @@ TEST_CASE("set receipt flags", M) {
 TEST_CASE("set restart needed flag", M) {
   IndexPtr ri = std::make_shared<Index>("Index Name");
   Category cat("Category Name", ri.get());
-  Package script(Package::ScriptType, "Package Name", &cat);
-  Package ext(Package::ExtensionType, "Package Name", &cat);
+  Package script(Package::ScriptType, "Package Name", &cat, "remote");
+  Package ext(Package::ExtensionType, "Package Name", &cat, "remote");
   Version scriptVer("1.0", &script);
   Version extVer("1.0", &ext);
 
@@ -147,7 +147,7 @@ TEST_CASE("format receipt page contents", M) {
 TEST_CASE("format install ticket", M) {
   IndexPtr ri = std::make_shared<Index>("Index Name");
   Category cat("Category Name", ri.get());
-  Package pkg(Package::ScriptType, "Package Name", &cat);
+  Package pkg(Package::ScriptType, "Package Name", &cat, "remote");
 
   Version *v1 = new Version("1.0", &pkg);
   v1->addSource(new Source({}, "https://google.com", v1));
@@ -207,13 +207,13 @@ TEST_CASE("format install ticket", M) {
 TEST_CASE("sort InstallTickets (case insensitive)", M) {
   IndexPtr ri = std::make_shared<Index>("Index Name");
   Category cat("Category Name", ri.get());
-  Package pkg1(Package::ScriptType, "a test", &cat);
+  Package pkg1(Package::ScriptType, "a test", &cat, "remote");
   Version ver1("1.0", &pkg1);
 
-  Package pkg2(Package::ScriptType, "Uppercase Name", &cat);
+  Package pkg2(Package::ScriptType, "Uppercase Name", &cat, "remote");
   Version ver2("1.0", &pkg2);
 
-  Package pkg3(Package::ScriptType, "unused name", &cat);
+  Package pkg3(Package::ScriptType, "unused name", &cat, "remote");
   pkg3.setDescription("z is the last letter");
   Version ver3("1.0", &pkg3);
 

--- a/test/registry.cpp
+++ b/test/registry.cpp
@@ -12,7 +12,7 @@ static const char *M = "[registry]";
 #define MAKE_PACKAGE \
   Index ri("Remote Name"); \
   Category cat("Category Name", &ri); \
-  Package pkg(Package::ScriptType, "Hello", &cat); \
+  Package pkg(Package::ScriptType, "Hello", &cat, "remote"); \
   pkg.setDescription("Hello World"); \
   Version ver("1.0", &pkg); \
   ver.setAuthor("John Doe"); \
@@ -77,7 +77,7 @@ TEST_CASE("bump version", M) {
   REQUIRE(entry2.version.toString() == "2.0");
   CHECK(entry2.author == "");
   REQUIRE(entry2.flags == 2);
-  
+
   REQUIRE(entry2.id == entry1.id);
 }
 
@@ -137,7 +137,7 @@ TEST_CASE("file conflicts", M) {
 
   Index ri("Remote Name");
   Category cat("Category Name", &ri);
-  Package pkg(Package::ScriptType, "Duplicate Package", &cat);
+  Package pkg(Package::ScriptType, "Duplicate Package", &cat, "remote");
   Version ver("1.0", &pkg);
   Source *src1 = new Source("file", "url", &ver);
   ver.addSource(src1);

--- a/test/source.cpp
+++ b/test/source.cpp
@@ -11,7 +11,7 @@ static const char *M = "[source]";
 #define MAKE_VERSION \
   Index ri("Index Name"); \
   Category cat("Category Name", &ri); \
-  Package pkg(Package::DataType, "Package Name", &cat); \
+  Package pkg(Package::DataType, "Package Name", &cat, "remote"); \
   Version ver("1.0", &pkg);
 
 TEST_CASE("source platform", M) {
@@ -97,7 +97,7 @@ TEST_CASE("implicit section detection from source (v1.0 compatibility)") {
 
   SECTION("main") {
     Category cat("Category Name", &ri);
-    Package pack(Package::ScriptType, "package name", &cat);
+    Package pack(Package::ScriptType, "package name", &cat, "remote");
     Version ver("1.0", &pack);
 
     Source source("filename", "url", &ver);
@@ -107,7 +107,7 @@ TEST_CASE("implicit section detection from source (v1.0 compatibility)") {
 
   SECTION("midi editor") {
     Category cat("MIDI Editor", &ri);
-    Package pack(Package::ScriptType, "package name", &cat);
+    Package pack(Package::ScriptType, "package name", &cat, "remote");
     Version ver("1.0", &pack);
 
     Source source("filename", "url", &ver);
@@ -154,7 +154,7 @@ TEST_CASE("source target path", M) {
 TEST_CASE("target path with parent directory traversal", M) {
   Index ri("Index Name");
   Category cat("Category Name", &ri);
-  Package pack(Package::ScriptType, "package name", &cat);
+  Package pack(Package::ScriptType, "package name", &cat, "remote");
   Version ver("1.0", &pack);
   Source source("../../../file.name", "url", &ver);
 
@@ -180,7 +180,7 @@ TEST_CASE("target path with parent directory traversal", M) {
 TEST_CASE("target path for unknown package type", M) {
   Index ri("name");
   Category cat("name", &ri);
-  Package pack(Package::UnknownType, "a", &cat);
+  Package pack(Package::UnknownType, "a", &cat, "remote");
   Version ver("1.0", &pack);
   Source src({}, "url", &ver);
 
@@ -190,7 +190,7 @@ TEST_CASE("target path for unknown package type", M) {
 TEST_CASE("directory traversal in category name", M) {
   Index ri("Remote Name");
   Category cat("../..", &ri);
-  Package pack(Package::ScriptType, "file.name", &cat);
+  Package pack(Package::ScriptType, "file.name", &cat, "remote");
   Version ver("1.0", &pack);
   Source src({}, "url", &ver);
 

--- a/test/version.cpp
+++ b/test/version.cpp
@@ -11,7 +11,7 @@
 #define MAKE_PACKAGE \
   Index ri("Index Name"); \
   Category cat("Category Name", &ri); \
-  Package pkg(Package::ScriptType, "Package Name", &cat); \
+  Package pkg(Package::ScriptType, "Package Name", &cat, "remote"); \
 
 static const char *M = "[version]";
 


### PR DESCRIPTION
(note: I haven't written C++ in ~20 years! all suggestions welcome)

I [posted in the forum dev thread](https://forums.cockos.com/showthread.php?p=2605740#post2605740) asking about workflow for developing reapacks. I found it a bit clunky to develop by adding scripts directly via actions, and then to elsewhere add a package.

It would be nice to install a package locally so it symlinks to files. Then as you edit the scripts, Reaper will pick up the updates automatically, just like if you added the scripts directly without ReaPack.

To use it, append `?symlink` to a `file://` repo URL, e.g. `file:///path/to/my/index.xml?symlink`. Install (or reinstall) a package, and it will symlink the files instead of copying them. Reaper picks up any changes you make to the script.

Tested on MacOS 10.15.6, REAPER 6.68