### PR TITLE
Move dependencies into vcpkg on all platforms

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,15 +34,11 @@ for:
       install-deps() {
         local arch="$1"; shift
         local native=("$@" php-cli qemu-user-binfmt)
-        local target=(
-          libboost-dev libcurl4-openssl-dev libsqlite3-dev libssl-dev
-          libxml2-dev zlib1g-dev
-        )
 
         sudo dpkg --add-architecture $arch
         sudo apt-get update -qq
         sudo apt-get install -qq aptitude > /dev/null
-        sudo aptitude install -yR ${native[@]} ${target[@]/%/:$arch} > /dev/null
+        sudo aptitude install -yR ${native[@]} > /dev/null
       }
 
       sudo update-alternatives --set gcc /usr/bin/gcc-7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(RUNTIME_OPENSSL
   "Load OpenSSL at runtime instead of linking against a specific version" OFF)

--- a/README.md
+++ b/README.md
@@ -6,52 +6,35 @@
 Visit the [ReaPack website](https://reapack.com/) for ready-to-use binaries,
 the user guide or the package upload tool.
 
-## Building from source
+## Building
 
-Clone the repository and submodules:
+Prerequisites:
 
+- [vcpkg](https://vcpkg.io/en/index.html)
+- [CMake](https://cmake.org/) 3.15 or newer
+- C++17 compiler
+- PHP (Linux and macOS)
+
+    # 1. Clone repository with submodules
     git clone --recursive --shallow-submodules https://github.com/cfillion/reapack.git
 
-### Prerequisites
+    # 2. Create build directory
+    mkdir build; cd build
 
-Software requirements:
+    # 3. Install dependencies and prepare files for build system
+    VCPKG_ROOT=path\to\vcpcg cmake -DCMAKE_BUILD_TYPE=Release ..
 
-- [CMake](https://cmake.org/) 3.15 or newer
-- C++17 compiler (MSVC on Windows)
-- PHP (Linux and macOS only)
+    # 4. Build
+    make
 
-#### Linux
-
-Install the following libraries (and development headers if your system provides
-them separately):
-
-- [Boost](https://www.boost.org/) (1.56 or later)
-- [Catch2](https://github.com/catchorg/Catch2) (3.0 or later)
-- [libcurl](https://curl.haxx.se/libcurl/)
-- [libxml2](http://www.xmlsoft.org/)
-- [OpenSSL](https://www.openssl.org/) or compatible
-- [SQLite](https://www.sqlite.org/)
-- [zlib](https://www.zlib.net/)
+    # 5. Install ReaPack into your REAPER installation
+    cmake --target install
 
 #### macOS
 
-Install Boost and Catch2 using [Homebrew](https://brew.sh) (recommended).
 The build tools can be installed using `xcode-select --install` or the Xcode IDE.
 
-#### Windows
-
-MSVC can be installed with the [Build Tools for Visual Studio](
-https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools)
-or the Visual Studio IDE.
-
-Use the x64 or x86 Native Tools Command Prompt for VS 20XX matching the target
-architecture when configuring or building ReaPack.
-
-Install [vcpkg](https://docs.microsoft.com/cpp/build/vcpkg) in any directory:
-
-    git clone https://github.com/Microsoft/vcpkg.git C:\path\to\vcpkg
-
-Set `VCPKG_TARGET_TRIPLET` and `CMAKE_TOOLCHAIN_FILE` when creating the build
+Set `VCPKG_TARGET_TRIPLET` and `VCPKG_ROOT` when creating the build
 tree:
 
     -DVCPKG_TARGET_TRIPLET=%PLATFORM%-windows-static
@@ -80,10 +63,6 @@ Alternatively, multiple build trees can be created if desired:
 To compile a build tree:
 
     cmake --build build
-
-To install ReaPack into your REAPER installation after building:
-
-    cmake --build build --target install
 
 The following targets are available:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,19 +4,14 @@ find_package(Boost 1.56 REQUIRED)
 find_package(CURL       REQUIRED)
 find_package(MiniZip    REQUIRED)
 find_package(Threads    REQUIRED)
+find_package(unofficial-sqlite3 REQUIRED)
 find_package(WDL        REQUIRED)
 
 if(WIN32)
-  # required for selecting the right debug or release version
-  find_package(unofficial-sqlite3 CONFIG REQUIRED)
-  add_library(SQLite::SQLite3 INTERFACE IMPORTED)
-  target_link_libraries(SQLite::SQLite3 INTERFACE unofficial::sqlite3::sqlite3)
-
   find_package(tinyxml2 CONFIG REQUIRED)
 else()
   find_package(SWELL REQUIRED)
   find_package(LibXml2 REQUIRED)
-  find_package(SQLite3 REQUIRED)
 
   if(NOT APPLE)
     find_package(OpenSSL REQUIRED COMPONENTS Crypto)
@@ -128,7 +123,7 @@ endif()
 
 target_link_libraries(reapack
   ${CMAKE_DL_LIBS} Boost::headers CURL::libcurl MiniZip::MiniZip
-  SQLite::SQLite3 Threads::Threads WDL::WDL
+  unofficial::sqlite3::sqlite3 Threads::Threads WDL::WDL
   $<IF:$<BOOL:${LIBXML2_FOUND}>,LibXml2::LibXml2,tinyxml2::tinyxml2>
 )
 target_compile_definitions(reapack PRIVATE CURL_DISABLE_DEPRECATION)

--- a/src/browser_entry.cpp
+++ b/src/browser_entry.cpp
@@ -22,8 +22,7 @@
 #include "menu.hpp"
 #include "reapack.hpp"
 #include "string.hpp"
-
-#include <boost/range/adaptor/reversed.hpp>
+#include "util/reverse_range.hpp"
 
 Browser::Entry::Entry(const Package *pkg, const Registry::Entry &re, const IndexPtr &i)
   : m_flags(0), regEntry(re), package(pkg), index(i), current(nullptr)
@@ -205,7 +204,7 @@ void Browser::Entry::fillMenu(Menu &menu) const
   else {
     const auto &versions = package->versions();
     int verIndex = static_cast<int>(versions.size());
-    for(const Version *ver : versions | boost::adaptors::reversed) {
+    for(const Version *ver : reverse_range(versions)) {
       const UINT actionIndex = versionMenu.addAction(
         ver->name().toString().c_str(), --verIndex | (ACTION_VERSION << 8));
 

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -19,9 +19,10 @@
 
 #include "errors.hpp"
 #include "index.hpp"
+#include "util/reverse_range.hpp"
 
 #include <algorithm>
-#include <boost/range/adaptor/reversed.hpp>
+#include <cstring>
 
 Package::Type Package::getType(const char *type)
 {
@@ -135,7 +136,7 @@ const Version *Package::lastVersion(const bool pres, const VersionName &from) co
   if(m_versions.empty())
     return nullptr;
 
-  for(const Version *ver : m_versions | boost::adaptors::reversed) {
+  for(const Version *ver : reverse_range(m_versions)) {
     if(ver->name() < from)
       break;
     else if(ver->name().isStable() || pres)

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -18,7 +18,6 @@
 #include "path.hpp"
 
 #include <algorithm>
-#include <boost/range/adaptor/reversed.hpp>
 #include <vector>
 
 static constexpr char UNIX_SEPARATOR = '/';

--- a/src/receipt.cpp
+++ b/src/receipt.cpp
@@ -16,11 +16,10 @@
  */
 
 #include "receipt.hpp"
-
+#include "util/reverse_range.hpp"
 #include "index.hpp"
 
 #include <boost/algorithm/string/case_conv.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <sstream>
 
 Receipt::Receipt()
@@ -141,7 +140,7 @@ std::ostream &operator<<(std::ostream &os, const InstallTicket &t)
   if(t.m_type == InstallTicket::Update) {
     const auto &versions = t.m_version->package()->versions();
 
-    for(const Version *ver : versions | boost::adaptors::reversed) {
+    for(const Version *ver : reverse_range(versions)) {
       if(ver->name() <= t.m_previous)
         break;
       else if(ver->name() <= t.m_version->name())

--- a/src/util/reverse_range.hpp
+++ b/src/util/reverse_range.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+template <class R> constexpr auto reverse_range(R &&r) {
+  using It = decltype(r.rbegin());
+
+  struct range {
+    constexpr It begin() { return rbegin; }
+    constexpr It end() { return rend; }
+    It rbegin, rend;
+  };
+
+  return range{r.rbegin(), r.rend()};
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,15 +2,15 @@
   "name": "reapack",
   "version-string": "current",
   "dependencies": [
-    { "name": "boost-algorithm",    "platform": "!linux" },
-    { "name": "boost-lexical-cast", "platform": "!linux" },
-    { "name": "boost-logic",        "platform": "!linux" },
-    { "name": "boost-math",         "platform": "!linux" },
-    { "name": "boost-preprocessor", "platform": "!linux" },
-    { "name": "boost-range",        "platform": "!linux" },
-    "catch2",
-    { "name": "curl",     "platform": "windows", "features": [ "non-http" ] },
+    "boost-algorithm",
+    "boost-lexical-cast",
+    "boost-logic",
+    "boost-preprocessor",
     "sqlite3",
-    { "name": "tinyxml2", "platform": "windows" }
+    "catch2",
+    { "name": "curl", "features": [ "non-http" ] },
+
+    { "name": "tinyxml2", "platform": "windows" },
+    { "name": "libxml2", "platform": "!windows" }
   ]
 }


### PR DESCRIPTION
Also get rid of boost-math (not used) and boost-range (used one function)