### PR TITLE
add missing include

### DIFF
--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -29,6 +29,8 @@
 #include "transaction.hpp"
 #include "win32.hpp"
 
+#include <algorithm>
+
 enum Timers { TIMER_FILTER = 1, TIMER_ABOUT };
 
 Browser::Browser()

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -32,6 +32,8 @@
 #include "transaction.hpp"
 #include "win32.hpp"
 
+#include <algorithm>
+
 static const Win32::char_type *ARCHIVE_FILTER =
   L("ReaPack Offline Archive (*.ReaPackArchive)\0*.ReaPackArchive\0");
 static const Win32::char_type *ARCHIVE_EXT = L("ReaPackArchive");


### PR DESCRIPTION
Hi there, I noticed with gcc version 14.1.0 there was a problem
I can change where you want the include. It look like the <system wide> includes are collected in relative .hpp file.
Here we see the problem
```
[ 20%] Building CXX object src/CMakeFiles/reapack.dir/api_misc.cpp.o
[ 22%] Building CXX object src/CMakeFiles/reapack.dir/api_package.cpp.o
[ 23%] Building CXX object src/CMakeFiles/reapack.dir/api_repo.cpp.o
[ 25%] Building CXX object src/CMakeFiles/reapack.dir/archive.cpp.o
[ 26%] Building CXX object src/CMakeFiles/reapack.dir/archive_tasks.cpp.o
[ 28%] Building CXX object src/CMakeFiles/reapack.dir/browser.cpp.o
/tmp/SSb/reapack/src/browser.cpp: In member function ‘void Browser::transferActions()’:
/tmp/SSb/reapack/src/browser.cpp:520:31: error: no matching function for call to ‘find(std::vector<Browser::Entry>::iterator, std::vector<Browser::Entry>::iterator, Browser::Entry&)’
  520 |     const auto &entryIt = find(m_entries.begin(), m_entries.end(), *oldEntry);
      |                           ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14.1.0/bits/locale_facets.h:48,
                 from /usr/include/c++/14.1.0/bits/basic_ios.h:37,
                 from /usr/include/c++/14.1.0/ios:46,
                 from /usr/include/c++/14.1.0/ostream:40,
                 from /tmp/SSb/reapack/src/path.hpp:22,
                 from /tmp/SSb/reapack/src/registry.hpp:23,
                 from /tmp/SSb/reapack/src/browser_entry.hpp:23,
                 from /tmp/SSb/reapack/src/browser.cpp:21:
/usr/include/c++/14.1.0/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14.1.0/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
/tmp/SSb/reapack/src/browser.cpp:520:31: note:   ‘__gnu_cxx::__normal_iterator<Browser::Entry*, std::vector<Browser::Entry> >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
  520 |     const auto &entryIt = find(m_entries.begin(), m_entries.end(), *oldEntry);
      |                           ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/SSb/reapack/src/browser.cpp: In member function ‘void Browser::fillList()’:
/tmp/SSb/reapack/src/browser.cpp:569:35: error: ‘find_if’ was not declared in this scope
  569 |     const auto &matchingEntryIt = find_if(oldSelection.begin(), oldSelection.end(),
      |                                   ^~~~~~~
/tmp/SSb/reapack/src/browser.cpp: In member function ‘bool Browser::hasAction(const Entry*) const’:
/tmp/SSb/reapack/src/browser.cpp:731:10: error: ‘count’ was not declared in this scope
  731 |   return count(m_actions.begin(), m_actions.end(), entry) > 0;
      |          ^~~~~
/tmp/SSb/reapack/src/browser.cpp: In member function ‘void Browser::updateAction(int)’:
/tmp/SSb/reapack/src/browser.cpp:774:24: error: no matching function for call to ‘find(std::__cxx11::list<Browser::Entry*>::iterator, std::__cxx11::list<Browser::Entry*>::iterator, Browser::Entry*&)’
  774 |   const auto &it = find(m_actions.begin(), m_actions.end(), entry);
      |                    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14.1.0/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14.1.0/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
/tmp/SSb/reapack/src/browser.cpp:774:24: note:   ‘std::_List_iterator<Browser::Entry*>’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
  774 |   const auto &it = find(m_actions.begin(), m_actions.end(), entry);
      |                    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/SSb/reapack/src/browser.cpp: In member function ‘bool Browser::confirm() const’:
/tmp/SSb/reapack/src/browser.cpp:843:24: error: ‘count_if’ was not declared in this scope; did you mean ‘count’?
  843 |   const size_t count = count_if(m_actions.begin(), m_actions.end(),
      |                        ^~~~~~~~
      |                        count
make[2]: *** [src/CMakeFiles/reapack.dir/build.make:197: src/CMakeFiles/reapack.dir/browser.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:287: src/CMakeFiles/reapack.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```