### PR TITLE
Adding ReaperLangPack Support for ReaPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ set_target_properties(reaper_reapack PROPERTIES
 add_subdirectory(src)
 target_link_libraries(reaper_reapack reapack)
 
+# Add langpack target
+add_executable(buildlangpack src/buildlangpack.cpp)
+target_include_directories(buildlangpack PRIVATE ${CMAKE_SOURCE_DIR}/vendor)
+target_link_libraries(buildlangpack WDL::WDL)
+
 add_subdirectory(test)
 add_custom_target(test
   COMMAND $<TARGET_FILE:tests>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
 endif()
 
 project(reapack LANGUAGES C CXX)
+if(MSVC)
+  add_compile_options(/utf-8)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/cmake/FindWDL.cmake
+++ b/cmake/FindWDL.cmake
@@ -14,7 +14,10 @@ set(WDL_DIR "${WDL_INCLUDE_DIR}/WDL")
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(WDL REQUIRED_VARS WDL_DIR WDL_INCLUDE_DIR)
 
-add_library(wdl ${WDL_DIR}/wingui/wndsize.cpp)
+add_library(wdl 
+  ${WDL_DIR}/wingui/wndsize.cpp
+  ${WDL_DIR}/localize/localize.cpp
+)
 
 target_compile_definitions(wdl INTERFACE WDL_NO_DEFINE_MINMAX)
 target_include_directories(wdl INTERFACE ${WDL_INCLUDE_DIR})

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -39,6 +39,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include <WDL/localize/localize.h>
+
 enum {
   ACTION_ABOUT_PKG = 300, ACTION_FIND_IN_BROWSER,
   ACTION_COPY_URL, ACTION_LOCATE
@@ -188,11 +190,11 @@ void About::setMetadata(const Metadata *metadata, const bool substitution)
   }
 
   if(aboutText.empty())
-    m_desc->setPlainText("This package or repository does not provide any documentation.");
+    m_desc->setPlainText(__LOCALIZE("This package or repository does not provide any documentation.", "reapack_about_error_msg"));
   else if(!m_desc->setRichText(aboutText))
-    m_desc->setPlainText("Could not load RTF document.");
+    m_desc->setPlainText(__LOCALIZE("Could not load RTF document.", "reapack_about_error_msg"));
 
-  m_tabs->addTab({"About", {m_desc->handle()}});
+  m_tabs->addTab({__LOCALIZE("About", "reapack"), {m_desc->handle()}});
 
   const auto &getLinkControl = [](const Metadata::LinkType type) {
     switch(type) {
@@ -292,24 +294,24 @@ void AboutIndexDelegate::init(About *dialog)
 
   dialog->setTitle(m_index->name());
   dialog->setMetadata(m_index->metadata(), m_index->name() == "ReaPack");
-  dialog->setAction("Install/update " + m_index->name());
+  dialog->setAction(__LOCALIZE("Install/update ", "reapack_about_button" ) + m_index->name());
 
-  dialog->tabs()->addTab({"Packages",
+  dialog->tabs()->addTab({__LOCALIZE("Packages", "reapack_about_tab"),
     {dialog->menu()->handle(), dialog->list()->handle()}});
-  dialog->tabs()->addTab({"Installed Files",
+  dialog->tabs()->addTab({__LOCALIZE("Installed Files", "reapack_about_tab"),
     {dialog->getControl(IDC_REPORT)}});
 
-  dialog->menu()->addColumn({"Category", 142});
+  dialog->menu()->addColumn({__LOCALIZE("Category", "reapack_about_column"), 142});
 
   dialog->menu()->reserveRows(m_index->categories().size() + 1);
-  dialog->menu()->createRow()->setCell(0, "<All Packages>");
+  dialog->menu()->createRow()->setCell(0, __LOCALIZE("<All Packages>", "reapack_about_menu"));
 
   for(const Category *cat : m_index->categories())
     dialog->menu()->createRow()->setCell(0, cat->name());
 
-  dialog->list()->addColumn({"Package", 382});
-  dialog->list()->addColumn({"Version", 80, 0, ListView::VersionType});
-  dialog->list()->addColumn({"Author", 90});
+  dialog->list()->addColumn({__LOCALIZE("Package", "reapack_about_column"), 382});
+  dialog->list()->addColumn({__LOCALIZE("Version", "reapack_about_column"), 80, 0, ListView::VersionType});
+  dialog->list()->addColumn({__LOCALIZE("Author", "reapack_about_column"), 90});
 
   initInstalledFiles();
 }
@@ -329,9 +331,9 @@ void AboutIndexDelegate::initInstalledFiles()
   }
   catch(const reapack_error &e) {
     Win32::setWindowText(report, String::format(
-      "The file list is currently unavailable.\x20"
+      __LOCALIZE("The file list is currently unavailable.\x20"
       "Retry later when all installation task are completed.\r\n"
-      "\r\nError description: %s", e.what()
+      "\r\nError description: %s", "reapack_about_error_msg"), e.what()
     ).c_str());
     return;
   }
@@ -387,8 +389,8 @@ bool AboutIndexDelegate::fillContextMenu(Menu &menu, const int index) const
   if(index < 0)
     return false;
 
-  menu.addAction("Find in the &browser", ACTION_FIND_IN_BROWSER);
-  menu.addAction("About this &package", ACTION_ABOUT_PKG);
+  menu.addAction(__LOCALIZE("Find in the &browser", "reapack_about_menu"), ACTION_FIND_IN_BROWSER);
+  menu.addAction(__LOCALIZE("About this &package", "reapack_about_menu"), ACTION_ABOUT_PKG);
 
   return true;
 }
@@ -457,9 +459,9 @@ void AboutIndexDelegate::install()
   enum { INSTALL_ALL = 80, UPDATE_ONLY, OPEN_BROWSER };
 
   Menu menu;
-  menu.addAction("Install all packages in this repository", INSTALL_ALL);
-  menu.addAction("Install individual packages in this repository", OPEN_BROWSER);
-  menu.addAction("Update installed packages only", UPDATE_ONLY);
+  menu.addAction(__LOCALIZE("Install all packages in this repository", "reapack_about_menu"), INSTALL_ALL);
+  menu.addAction(__LOCALIZE("Install individual packages in this repository", "reapack_about_menu"), OPEN_BROWSER);
+  menu.addAction(__LOCALIZE("Update installed packages only", "reapack_about_menu"), UPDATE_ONLY);
 
   const int choice = menu.show(m_dialog->getControl(IDC_ACTION), m_dialog->handle());
 
@@ -471,7 +473,7 @@ void AboutIndexDelegate::install()
   if(!remote) {
     // In case the user uninstalled the repository while this dialog was opened
     Win32::messageBox(m_dialog->handle(),
-      "This repository cannot be found in your current configuration.",
+      __LOCALIZE("This repository cannot be found in your current configuration.", "reapack_about_error_msg"),
       "ReaPack", MB_OK);
     return;
   }
@@ -491,11 +493,11 @@ void AboutIndexDelegate::install()
   if(choice == INSTALL_ALL && boost::logic::indeterminate(remote.autoInstall())
       && !installOpts.autoInstall) {
     const int btn = Win32::messageBox(m_dialog->handle(),
-      "Do you want ReaPack to install new packages from this repository"
+      __LOCALIZE("Do you want ReaPack to install new packages from this repository"
       " when synchronizing in the future?\n\nThis setting can also be"
       " customized globally or on a per-repository basis in"
-      " ReaPack > Manage repositories.",
-      "Install all packages in this repository", MB_YESNOCANCEL);
+      " ReaPack > Manage repositories.", "reapack_about_msg"),
+      __LOCALIZE("Install all packages in this repository", "reapack_about_msg"), MB_YESNOCANCEL);
 
     switch(btn) {
     case IDYES:
@@ -533,16 +535,16 @@ void AboutPackageDelegate::init(About *dialog)
   dialog->setMetadata(m_package->metadata());
   dialog->setAction("About " + m_index->name());
 
-  dialog->tabs()->addTab({"History",
+  dialog->tabs()->addTab({__LOCALIZE("History", "reapack_about_tab"),
     {dialog->menu()->handle(), dialog->getControl(IDC_CHANGELOG)}});
-  dialog->tabs()->addTab({"Contents",
+  dialog->tabs()->addTab({__LOCALIZE("Contents", "reapack_about_tab"),
     {dialog->menu()->handle(), dialog->list()->handle()}});
 
-  dialog->menu()->addColumn({"Version", 142, 0, ListView::VersionType});
+  dialog->menu()->addColumn({__LOCALIZE("Version", "reapack_about_column"), 142, 0, ListView::VersionType});
 
-  dialog->list()->addColumn({"File", 267});
-  dialog->list()->addColumn({"Path", 207});
-  dialog->list()->addColumn({"Action List", 84});
+  dialog->list()->addColumn({__LOCALIZE("File", "reapack_about_column"), 267});
+  dialog->list()->addColumn({__LOCALIZE("Path", "reapack_about_column"), 207});
+  dialog->list()->addColumn({__LOCALIZE("Action List", "reapack_about_column"), 84});
 
   dialog->menu()->reserveRows(m_package->versions().size());
 
@@ -562,13 +564,13 @@ void AboutPackageDelegate::init(About *dialog)
 
 void AboutPackageDelegate::updateList(const int index)
 {
-  constexpr std::pair<Source::Section, const char *> sectionMap[] {
-    {Source::MainSection,                "Main"},
-    {Source::MIDIEditorSection,          "MIDI Editor"},
-    {Source::MIDIInlineEditorSection,    "MIDI Inline Editor"},
-    {Source::MIDIEventListEditorSection, "MIDI Event List Editor"},
-    {Source::MediaExplorerSection,       "Media Explorer"},
-    {Source::CrossfadeEditorSection,     "Crossfade Editor"},
+  static const std::pair<Source::Section, const char *> sectionMap[] {
+    {Source::MainSection,                __LOCALIZE("Main", "reapack_about_source")},
+    {Source::MIDIEditorSection,          __LOCALIZE("MIDI Editor", "reapack_about_source")},
+    {Source::MIDIInlineEditorSection,    __LOCALIZE("MIDI Inline Editor", "reapack_about_source")},
+    {Source::MIDIEventListEditorSection, __LOCALIZE("MIDI Event List Editor", "reapack_about_source")},
+    {Source::MediaExplorerSection,       __LOCALIZE("Media Explorer", "reapack_about_source")},
+    {Source::CrossfadeEditorSection,     __LOCALIZE("Crossfade Editor", "reapack_about_source")},
   };
 
   if(index < 0)
@@ -596,14 +598,14 @@ void AboutPackageDelegate::updateList(const int index)
       }
 
       if(sections) // In case we forgot to add a section to sectionMap!
-        sectionNames.push_back("Other");
+        sectionNames.push_back(__LOCALIZE("Other", "reapack_about_source"));
 
-      actionList = "Yes (";
+      actionList = __LOCALIZE("Yes", "reapack") + std::string(" (");
       actionList += boost::algorithm::join(sectionNames, ", ");
       actionList += ')';
     }
     else
-      actionList = "No";
+      actionList = __LOCALIZE("No", "reapack");
 
     int c = 0;
     auto row = m_dialog->list()->createRow((void *)src);
@@ -620,9 +622,9 @@ bool AboutPackageDelegate::fillContextMenu(Menu &menu, const int index) const
 
   auto src = static_cast<const Source *>(m_dialog->list()->row(index)->userData);
 
-  menu.addAction("Copy source URL", ACTION_COPY_URL);
+  menu.addAction(__LOCALIZE("Copy source URL", "reapack_about_menu"), ACTION_COPY_URL);
   menu.setEnabled(m_current.size() > 0 && FS::exists(src->targetPath()),
-    menu.addAction("Locate in explorer/finder", ACTION_LOCATE));
+    menu.addAction(__LOCALIZE("Locate in explorer/finder", "reapack_about_menu"), ACTION_LOCATE));
 
   return true;
 }

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -190,11 +190,11 @@ void About::setMetadata(const Metadata *metadata, const bool substitution)
   }
 
   if(aboutText.empty())
-    m_desc->setPlainText(__LOCALIZE("This package or repository does not provide any documentation.", "reapack_about_error_msg"));
+    m_desc->setPlainText(__LOCALIZE("This package or repository does not provide any documentation.", "reapack_about"));
   else if(!m_desc->setRichText(aboutText))
-    m_desc->setPlainText(__LOCALIZE("Could not load RTF document.", "reapack_about_error_msg"));
+    m_desc->setPlainText(__LOCALIZE("Could not load RTF document.", "reapack_about"));
 
-  m_tabs->addTab({__LOCALIZE("About", "reapack"), {m_desc->handle()}});
+  m_tabs->addTab({__LOCALIZE("About", "reapack_about"), {m_desc->handle()}});
 
   const auto &getLinkControl = [](const Metadata::LinkType type) {
     switch(type) {
@@ -294,24 +294,24 @@ void AboutIndexDelegate::init(About *dialog)
 
   dialog->setTitle(m_index->name());
   dialog->setMetadata(m_index->metadata(), m_index->name() == "ReaPack");
-  dialog->setAction(__LOCALIZE("Install/update ", "reapack_about_button" ) + m_index->name());
+  dialog->setAction(__LOCALIZE("Install/update ", "reapack_about" ) + m_index->name());
 
-  dialog->tabs()->addTab({__LOCALIZE("Packages", "reapack_about_tab"),
+  dialog->tabs()->addTab({__LOCALIZE("Packages", "reapack_about"),
     {dialog->menu()->handle(), dialog->list()->handle()}});
-  dialog->tabs()->addTab({__LOCALIZE("Installed Files", "reapack_about_tab"),
+  dialog->tabs()->addTab({__LOCALIZE("Installed Files", "reapack_about"),
     {dialog->getControl(IDC_REPORT)}});
 
-  dialog->menu()->addColumn({__LOCALIZE("Category", "reapack_about_column"), 142});
+  dialog->menu()->addColumn({__LOCALIZE("Category", "reapack_about"), 142});
 
   dialog->menu()->reserveRows(m_index->categories().size() + 1);
-  dialog->menu()->createRow()->setCell(0, __LOCALIZE("<All Packages>", "reapack_about_menu"));
+  dialog->menu()->createRow()->setCell(0, __LOCALIZE("<All Packages>", "reapack_about"));
 
   for(const Category *cat : m_index->categories())
     dialog->menu()->createRow()->setCell(0, cat->name());
 
-  dialog->list()->addColumn({__LOCALIZE("Package", "reapack_about_column"), 382});
-  dialog->list()->addColumn({__LOCALIZE("Version", "reapack_about_column"), 80, 0, ListView::VersionType});
-  dialog->list()->addColumn({__LOCALIZE("Author", "reapack_about_column"), 90});
+  dialog->list()->addColumn({__LOCALIZE("Package", "reapack_about"), 382});
+  dialog->list()->addColumn({__LOCALIZE("Version", "reapack_about"), 80, 0, ListView::VersionType});
+  dialog->list()->addColumn({__LOCALIZE("Author", "reapack_about"), 90});
 
   initInstalledFiles();
 }
@@ -333,7 +333,7 @@ void AboutIndexDelegate::initInstalledFiles()
     Win32::setWindowText(report, String::format(
       __LOCALIZE("The file list is currently unavailable.\x20"
       "Retry later when all installation task are completed.\r\n"
-      "\r\nError description: %s", "reapack_about_error_msg"), e.what()
+      "\r\nError description: %s", "reapack_about"), e.what()
     ).c_str());
     return;
   }
@@ -389,8 +389,8 @@ bool AboutIndexDelegate::fillContextMenu(Menu &menu, const int index) const
   if(index < 0)
     return false;
 
-  menu.addAction(__LOCALIZE("Find in the &browser", "reapack_about_menu"), ACTION_FIND_IN_BROWSER);
-  menu.addAction(__LOCALIZE("About this &package", "reapack_about_menu"), ACTION_ABOUT_PKG);
+  menu.addAction(__LOCALIZE("Find in the &browser", "reapack_about"), ACTION_FIND_IN_BROWSER);
+  menu.addAction(__LOCALIZE("About this &package", "reapack_about"), ACTION_ABOUT_PKG);
 
   return true;
 }
@@ -459,9 +459,9 @@ void AboutIndexDelegate::install()
   enum { INSTALL_ALL = 80, UPDATE_ONLY, OPEN_BROWSER };
 
   Menu menu;
-  menu.addAction(__LOCALIZE("Install all packages in this repository", "reapack_about_menu"), INSTALL_ALL);
-  menu.addAction(__LOCALIZE("Install individual packages in this repository", "reapack_about_menu"), OPEN_BROWSER);
-  menu.addAction(__LOCALIZE("Update installed packages only", "reapack_about_menu"), UPDATE_ONLY);
+  menu.addAction(__LOCALIZE("Install all packages in this repository", "reapack_about"), INSTALL_ALL);
+  menu.addAction(__LOCALIZE("Install individual packages in this repository", "reapack_about"), OPEN_BROWSER);
+  menu.addAction(__LOCALIZE("Update installed packages only", "reapack_about"), UPDATE_ONLY);
 
   const int choice = menu.show(m_dialog->getControl(IDC_ACTION), m_dialog->handle());
 
@@ -473,7 +473,7 @@ void AboutIndexDelegate::install()
   if(!remote) {
     // In case the user uninstalled the repository while this dialog was opened
     Win32::messageBox(m_dialog->handle(),
-      __LOCALIZE("This repository cannot be found in your current configuration.", "reapack_about_error_msg"),
+      __LOCALIZE("This repository cannot be found in your current configuration.", "reapack_about"),
       "ReaPack", MB_OK);
     return;
   }
@@ -496,8 +496,8 @@ void AboutIndexDelegate::install()
       __LOCALIZE("Do you want ReaPack to install new packages from this repository"
       " when synchronizing in the future?\n\nThis setting can also be"
       " customized globally or on a per-repository basis in"
-      " ReaPack > Manage repositories.", "reapack_about_msg"),
-      __LOCALIZE("Install all packages in this repository", "reapack_about_msg"), MB_YESNOCANCEL);
+      " ReaPack > Manage repositories.", "reapack_about"),
+      __LOCALIZE("Install all packages in this repository", "reapack_about"), MB_YESNOCANCEL);
 
     switch(btn) {
     case IDYES:
@@ -535,16 +535,16 @@ void AboutPackageDelegate::init(About *dialog)
   dialog->setMetadata(m_package->metadata());
   dialog->setAction("About " + m_index->name());
 
-  dialog->tabs()->addTab({__LOCALIZE("History", "reapack_about_tab"),
+  dialog->tabs()->addTab({__LOCALIZE("History", "reapack_about"),
     {dialog->menu()->handle(), dialog->getControl(IDC_CHANGELOG)}});
-  dialog->tabs()->addTab({__LOCALIZE("Contents", "reapack_about_tab"),
+  dialog->tabs()->addTab({__LOCALIZE("Contents", "reapack_about"),
     {dialog->menu()->handle(), dialog->list()->handle()}});
 
-  dialog->menu()->addColumn({__LOCALIZE("Version", "reapack_about_column"), 142, 0, ListView::VersionType});
+  dialog->menu()->addColumn({__LOCALIZE("Version", "reapack_about"), 142, 0, ListView::VersionType});
 
-  dialog->list()->addColumn({__LOCALIZE("File", "reapack_about_column"), 267});
-  dialog->list()->addColumn({__LOCALIZE("Path", "reapack_about_column"), 207});
-  dialog->list()->addColumn({__LOCALIZE("Action List", "reapack_about_column"), 84});
+  dialog->list()->addColumn({__LOCALIZE("File", "reapack_about"), 267});
+  dialog->list()->addColumn({__LOCALIZE("Path", "reapack_about"), 207});
+  dialog->list()->addColumn({__LOCALIZE("Action List", "reapack_about"), 84});
 
   dialog->menu()->reserveRows(m_package->versions().size());
 
@@ -565,12 +565,12 @@ void AboutPackageDelegate::init(About *dialog)
 void AboutPackageDelegate::updateList(const int index)
 {
   static const std::pair<Source::Section, const char *> sectionMap[] {
-    {Source::MainSection,                __LOCALIZE("Main", "reapack_about_source")},
-    {Source::MIDIEditorSection,          __LOCALIZE("MIDI Editor", "reapack_about_source")},
-    {Source::MIDIInlineEditorSection,    __LOCALIZE("MIDI Inline Editor", "reapack_about_source")},
-    {Source::MIDIEventListEditorSection, __LOCALIZE("MIDI Event List Editor", "reapack_about_source")},
-    {Source::MediaExplorerSection,       __LOCALIZE("Media Explorer", "reapack_about_source")},
-    {Source::CrossfadeEditorSection,     __LOCALIZE("Crossfade Editor", "reapack_about_source")},
+    {Source::MainSection,                __LOCALIZE("Main", "reapack_about")},
+    {Source::MIDIEditorSection,          __LOCALIZE("MIDI Editor", "reapack_about")},
+    {Source::MIDIInlineEditorSection,    __LOCALIZE("MIDI Inline Editor", "reapack_about")},
+    {Source::MIDIEventListEditorSection, __LOCALIZE("MIDI Event List Editor", "reapack_about")},
+    {Source::MediaExplorerSection,       __LOCALIZE("Media Explorer", "reapack_about")},
+    {Source::CrossfadeEditorSection,     __LOCALIZE("Crossfade Editor", "reapack_about")},
   };
 
   if(index < 0)
@@ -598,14 +598,14 @@ void AboutPackageDelegate::updateList(const int index)
       }
 
       if(sections) // In case we forgot to add a section to sectionMap!
-        sectionNames.push_back(__LOCALIZE("Other", "reapack_about_source"));
+        sectionNames.push_back(__LOCALIZE("Other", "reapack_about"));
 
-      actionList = __LOCALIZE("Yes", "reapack") + std::string(" (");
+      actionList = __LOCALIZE("Yes", "reapack_about") + std::string(" (");
       actionList += boost::algorithm::join(sectionNames, ", ");
       actionList += ')';
     }
     else
-      actionList = __LOCALIZE("No", "reapack");
+      actionList = __LOCALIZE("No", "reapack_about");
 
     int c = 0;
     auto row = m_dialog->list()->createRow((void *)src);
@@ -622,9 +622,9 @@ bool AboutPackageDelegate::fillContextMenu(Menu &menu, const int index) const
 
   auto src = static_cast<const Source *>(m_dialog->list()->row(index)->userData);
 
-  menu.addAction(__LOCALIZE("Copy source URL", "reapack_about_menu"), ACTION_COPY_URL);
+  menu.addAction(__LOCALIZE("Copy source URL", "reapack_about"), ACTION_COPY_URL);
   menu.setEnabled(m_current.size() > 0 && FS::exists(src->targetPath()),
-    menu.addAction(__LOCALIZE("Locate in explorer/finder", "reapack_about_menu"), ACTION_LOCATE));
+    menu.addAction(__LOCALIZE("Locate in explorer/finder", "reapack_about"), ACTION_LOCATE));
 
   return true;
 }

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -25,6 +25,7 @@
 #include "reapack.hpp"
 #include "transaction.hpp"
 #include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <fstream>
 #include <iomanip>
@@ -78,7 +79,7 @@ void Archive::import(const std::string &path)
   std::stringstream toc;
   if(const int err = state.m_reader->extractFile(ARCHIVE_TOC, toc))
     throw reapack_error(String::format(
-      "Cannot locate the table of contents (%d)", err));
+      __LOCALIZE("Cannot locate the table of contents (%d)", "reapack_error_msg"), err));
 
   // starting import, do not abort process (eg. by throwing) at this point
   if(!(state.m_tx = g_reapack->setupTransaction()))
@@ -100,7 +101,7 @@ void Archive::import(const std::string &path)
         state.importPackage(data);
         break;
       default:
-        throw reapack_error(String::format("Unknown token '%s' (skipping)",
+        throw reapack_error(String::format(__LOCALIZE("Unknown token '%s' (skipping)", "reapack_error_msg"),
           line.substr(0, 4).c_str()));
       }
     }
@@ -119,7 +120,7 @@ void ImportArchive::importRemote(const std::string &data)
   Remote remote = Remote::fromString(data);
 
   if(const int err = m_reader->extractFile(Index::pathFor(remote.name()))) {
-    throw reapack_error(String::format("Failed to extract index of %s (%d)",
+    throw reapack_error(String::format(__LOCALIZE("Failed to extract index of %s (%d)", "reapack_error_msg"),
       remote.name().c_str(), err));
   }
 
@@ -153,7 +154,7 @@ void ImportArchive::importPackage(const std::string &data)
 
   if(!ver) {
     throw reapack_error(String::format(
-      "%s/%s/%s v%s cannot be found or is incompatible with your operating system.",
+      __LOCALIZE("%s/%s/%s v%s cannot be found or is incompatible with your operating system.", "reapack_error_msg"),
       m_lastIndex->name().c_str(), categoryName.c_str(),
       packageName.c_str(), versionName.c_str()));
   }
@@ -236,7 +237,7 @@ bool FileExtractor::run()
   stream.close();
 
   if(error) {
-    setError({String::format("Failed to extract file (%d)", error),
+    setError({String::format(__LOCALIZE("Failed to extract file (%d)", "reapack_error_msg"), error),
       m_path.target().join()});
     return false;
   }
@@ -303,7 +304,7 @@ int ArchiveWriter::addFile(const Path &path, std::istream &stream) noexcept
 FileCompressor::FileCompressor(const Path &target, const ArchiveWriterPtr &writer)
   : m_path(target), m_writer(writer)
 {
-  setSummary({ "Compressing", target.join() });
+  setSummary({ __LOCALIZE("Compressing", "reapack_archive"), target.join() });
 }
 
 bool FileCompressor::run()
@@ -311,7 +312,7 @@ bool FileCompressor::run()
   std::ifstream stream;
   if(!FS::open(stream, m_path)) {
     setError({
-      String::format("Could not open file for export (%s)", FS::lastError()),
+      String::format(__LOCALIZE("Could not open file for export (%s)", "reapack_error_msg"), FS::lastError()),
       m_path.join()});
     return false;
   }
@@ -320,7 +321,7 @@ bool FileCompressor::run()
   stream.close();
 
   if(error) {
-    setError({String::format("Failed to compress file (%d)", error), m_path.join()});
+    setError({String::format(__LOCALIZE("Failed to compress file (%d)", "reapack_error_msg"), error), m_path.join()});
     return false;
   }
 

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -79,7 +79,7 @@ void Archive::import(const std::string &path)
   std::stringstream toc;
   if(const int err = state.m_reader->extractFile(ARCHIVE_TOC, toc))
     throw reapack_error(String::format(
-      __LOCALIZE("Cannot locate the table of contents (%d)", "reapack_error_msg"), err));
+      __LOCALIZE("Cannot locate the table of contents (%d)", "reapack_archive"), err));
 
   // starting import, do not abort process (eg. by throwing) at this point
   if(!(state.m_tx = g_reapack->setupTransaction()))
@@ -101,7 +101,7 @@ void Archive::import(const std::string &path)
         state.importPackage(data);
         break;
       default:
-        throw reapack_error(String::format(__LOCALIZE("Unknown token '%s' (skipping)", "reapack_error_msg"),
+        throw reapack_error(String::format(__LOCALIZE("Unknown token '%s' (skipping)", "reapack_archive"),
           line.substr(0, 4).c_str()));
       }
     }
@@ -120,7 +120,7 @@ void ImportArchive::importRemote(const std::string &data)
   Remote remote = Remote::fromString(data);
 
   if(const int err = m_reader->extractFile(Index::pathFor(remote.name()))) {
-    throw reapack_error(String::format(__LOCALIZE("Failed to extract index of %s (%d)", "reapack_error_msg"),
+    throw reapack_error(String::format(__LOCALIZE("Failed to extract index of %s (%d)", "reapack_archive"),
       remote.name().c_str(), err));
   }
 
@@ -154,7 +154,7 @@ void ImportArchive::importPackage(const std::string &data)
 
   if(!ver) {
     throw reapack_error(String::format(
-      __LOCALIZE("%s/%s/%s v%s cannot be found or is incompatible with your operating system.", "reapack_error_msg"),
+      __LOCALIZE("%s/%s/%s v%s cannot be found or is incompatible with your operating system.", "reapack_archive"),
       m_lastIndex->name().c_str(), categoryName.c_str(),
       packageName.c_str(), versionName.c_str()));
   }
@@ -237,7 +237,7 @@ bool FileExtractor::run()
   stream.close();
 
   if(error) {
-    setError({String::format(__LOCALIZE("Failed to extract file (%d)", "reapack_error_msg"), error),
+    setError({String::format(__LOCALIZE("Failed to extract file (%d)", "reapack_archive"), error),
       m_path.target().join()});
     return false;
   }
@@ -312,7 +312,7 @@ bool FileCompressor::run()
   std::ifstream stream;
   if(!FS::open(stream, m_path)) {
     setError({
-      String::format(__LOCALIZE("Could not open file for export (%s)", "reapack_error_msg"), FS::lastError()),
+      String::format(__LOCALIZE("Could not open file for export (%s)", "reapack_archive"), FS::lastError()),
       m_path.join()});
     return false;
   }
@@ -321,7 +321,7 @@ bool FileCompressor::run()
   stream.close();
 
   if(error) {
-    setError({String::format(__LOCALIZE("Failed to compress file (%d)", "reapack_error_msg"), error), m_path.join()});
+    setError({String::format(__LOCALIZE("Failed to compress file (%d)", "reapack_archive"), error), m_path.join()});
     return false;
   }
 

--- a/src/archive_tasks.cpp
+++ b/src/archive_tasks.cpp
@@ -28,6 +28,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <WDL/localize/localize.h>
 
 static const Path ARCHIVE_TOC("toc");
 
@@ -46,7 +47,7 @@ bool ExportTask::start()
   }
   catch(const reapack_error &e) {
     tx()->receipt()->addError({
-      String::format("Could not open archive for writing: %s", e.what()),
+      String::format(__LOCALIZE("Could not open archive for writing: %s", "reapack_archive_tasks"), e.what()),
       m_path.temp().join()
     });
     return false;
@@ -97,7 +98,7 @@ void ExportTask::commit()
 {
   if(!FS::rename(m_path)) {
     tx()->receipt()->addError({
-      String::format("Could not move to permanent location: %s", FS::lastError()),
+      String::format(__LOCALIZE("Could not move to permanent location: %s", "reapack_archive_tasks"), FS::lastError()),
       m_path.target().prependRoot().join()
     });
   }

--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -52,23 +52,23 @@ void Browser::onInit()
   disable(m_actionsBtn);
 
   // don't forget to update order of enum View in header file
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("All", "reapack_browser_display_dropdown"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Queued", "reapack_browser_display_dropdown"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Installed", "reapack_browser_display_dropdown"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Out of date", "reapack_browser_display_dropdown"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Obsolete", "reapack_browser_display_dropdown"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Uninstalled", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("All", "reapack_browser"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Queued", "reapack_browser"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Installed", "reapack_browser"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Out of date", "reapack_browser"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Obsolete", "reapack_browser"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Uninstalled", "reapack_browser"));
   SendMessage(m_view, CB_SETCURSEL, 0, 0);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {__LOCALIZE("Status", "reapack_browser_column"),       23, ListView::NoLabelFlag},
-    {__LOCALIZE("Package", "reapack_browser_column"),     345, ListView::FilterFlag},
-    {__LOCALIZE("Category", "reapack_browser_column"),    105, ListView::FilterFlag},
-    {__LOCALIZE("Version", "reapack_browser_column"),      55, 0, ListView::VersionType},
-    {__LOCALIZE("Author", "reapack_browser_column"),       95, ListView::FilterFlag},
-    {__LOCALIZE("Type", "reapack_browser_column"),         70},
-    {__LOCALIZE("Repository", "reapack_browser_column"),  120, ListView::CollapseFlag | ListView::FilterFlag},
-    {__LOCALIZE("Last Update", "reapack_browser_column"), 105, 0, ListView::TimeType},
+    {__LOCALIZE("Status", "reapack_browser"),       23, ListView::NoLabelFlag},
+    {__LOCALIZE("Package", "reapack_browser"),     345, ListView::FilterFlag},
+    {__LOCALIZE("Category", "reapack_browser"),    105, ListView::FilterFlag},
+    {__LOCALIZE("Version", "reapack_browser"),      55, 0, ListView::VersionType},
+    {__LOCALIZE("Author", "reapack_browser"),       95, ListView::FilterFlag},
+    {__LOCALIZE("Type", "reapack_browser"),         70},
+    {__LOCALIZE("Repository", "reapack_browser"),  120, ListView::CollapseFlag | ListView::FilterFlag},
+    {__LOCALIZE("Last Update", "reapack_browser"), 105, 0, ListView::TimeType},
   });
 
   m_list->onActivate >> [=] { aboutPackage(m_list->itemUnderMouse()); };
@@ -266,8 +266,8 @@ bool Browser::fillContextMenu(Menu &menu, const int index)
   m_currentIndex = index;
   fillMenu(menu);
 
-  menu.addAction(__LOCALIZE("&Select all", "reapack_browser_menu"), IDC_SELECT);
-  menu.addAction(__LOCALIZE("&Unselect all", "reapack_browser_menu"), IDC_UNSELECT);
+  menu.addAction(__LOCALIZE("&Select all", "reapack_browser"), IDC_SELECT);
+  menu.addAction(__LOCALIZE("&Unselect all", "reapack_browser"), IDC_UNSELECT);
 
   return true;
 }
@@ -281,7 +281,7 @@ void Browser::fillMenu(Menu &menu)
 
     if(entry) {
       menu.addSeparator();
-      Menu pkgMenu = menu.addMenu(__LOCALIZE("Package under cursor", "reapack_browser_multiselected"));
+      Menu pkgMenu = menu.addMenu(__LOCALIZE("Package under cursor", "reapack_browser"));
       entry->fillMenu(pkgMenu);
     }
   }
@@ -292,7 +292,7 @@ void Browser::fillMenu(Menu &menu)
     menu.addSeparator();
 
   if(m_list->hasSelection())
-    menu.addAction(__LOCALIZE("&Copy package name", "reapack_browser_menu"), ACTION_COPY);
+    menu.addAction(__LOCALIZE("&Copy package name", "reapack_browser"), ACTION_COPY);
 }
 
 void Browser::fillSelectionMenu(Menu &menu)
@@ -303,18 +303,18 @@ void Browser::fillSelectionMenu(Menu &menu)
     selFlags |= getEntry(index)->possibleActions(false);
 
   menu.setEnabled(selFlags & Entry::CanInstallLatest,
-    menu.addAction(__LOCALIZE("&Install/update selection", "reapack_browser_menu"), ACTION_LATEST_ALL));
+    menu.addAction(__LOCALIZE("&Install/update selection", "reapack_browser"), ACTION_LATEST_ALL));
   menu.setEnabled(selFlags & Entry::CanReinstall,
-    menu.addAction(__LOCALIZE("&Reinstall selection", "reapack_browser_menu"), ACTION_REINSTALL_ALL));
+    menu.addAction(__LOCALIZE("&Reinstall selection", "reapack_browser"), ACTION_REINSTALL_ALL));
   menu.setEnabled(selFlags & Entry::CanUninstall,
-    menu.addAction(__LOCALIZE("&Uninstall selection", "reapack_browser_menu"), ACTION_UNINSTALL_ALL));
+    menu.addAction(__LOCALIZE("&Uninstall selection", "reapack_browser"), ACTION_UNINSTALL_ALL));
   menu.setEnabled(selFlags & Entry::CanClearQueued,
-    menu.addAction(__LOCALIZE("&Clear queued actions", "reapack_browser_menu"), ACTION_RESET_ALL));
+    menu.addAction(__LOCALIZE("&Clear queued actions", "reapack_browser"), ACTION_RESET_ALL));
 }
 
 void Browser::updateDisplayLabel()
 {
-  Win32::setWindowText(m_displayBtn, String::format(__LOCALIZE("%s/%s package%s...", "reapack_browser_button"), 
+  Win32::setWindowText(m_displayBtn, String::format(__LOCALIZE("%s/%s package%s...", "reapack_browser"), 
     String::number(m_list->visibleRowCount()).c_str(),
     String::number(m_entries.size()).c_str(), m_entries.size() == 1 ? "" : "s"
   ).c_str());
@@ -323,24 +323,24 @@ void Browser::updateDisplayLabel()
 void Browser::displayButton()
 {
   static const std::pair<const char *, Package::Type> types[] {
-    {__LOCALIZE("&Automation Items", "reapack_browser_packages_menu"),  Package::AutomationItemType},
-    {__LOCALIZE("&Effects", "reapack_browser_packages_menu"),           Package::EffectType},
-    {__LOCALIZE("E&xtensions", "reapack_browser_packages_menu"),        Package::ExtensionType},
-    {__LOCALIZE("&Key Maps", "reapack_browser_packages_menu"),          Package::KeymapType},
-    {__LOCALIZE("&Language Packs", "reapack_browser_packages_menu"),    Package::LangPackType},
-    {__LOCALIZE("&MIDI Note Names", "reapack_browser_packages_menu"),   Package::MIDINoteNamesType},
-    {__LOCALIZE("&Project Templates", "reapack_browser_packages_menu"), Package::ProjectTemplateType},
-    {__LOCALIZE("&Scripts", "reapack_browser_packages_menu"),           Package::ScriptType},
-    {__LOCALIZE("&Themes", "reapack_browser_packages_menu"),            Package::ThemeType},
-    {__LOCALIZE("&Track Templates", "reapack_browser_packages_menu"),   Package::TrackTemplateType},
-    {__LOCALIZE("&Web Interfaces", "reapack_browser_packages_menu"),    Package::WebInterfaceType},
+    {__LOCALIZE("&Automation Items", "reapack_browser"),  Package::AutomationItemType},
+    {__LOCALIZE("&Effects", "reapack_browser"),           Package::EffectType},
+    {__LOCALIZE("E&xtensions", "reapack_browser"),        Package::ExtensionType},
+    {__LOCALIZE("&Key Maps", "reapack_browser"),          Package::KeymapType},
+    {__LOCALIZE("&Language Packs", "reapack_browser"),    Package::LangPackType},
+    {__LOCALIZE("&MIDI Note Names", "reapack_browser"),   Package::MIDINoteNamesType},
+    {__LOCALIZE("&Project Templates", "reapack_browser"), Package::ProjectTemplateType},
+    {__LOCALIZE("&Scripts", "reapack_browser"),           Package::ScriptType},
+    {__LOCALIZE("&Themes", "reapack_browser"),            Package::ThemeType},
+    {__LOCALIZE("&Track Templates", "reapack_browser"),   Package::TrackTemplateType},
+    {__LOCALIZE("&Web Interfaces", "reapack_browser"),    Package::WebInterfaceType},
 
-    {__LOCALIZE("&Other packages", "reapack_browser_packages_menu"),    Package::UnknownType},
+    {__LOCALIZE("&Other packages", "reapack_browser"),    Package::UnknownType},
   };
 
   Menu menu;
 
-  auto index = menu.addAction(__LOCALIZE("&All packages", "reapack_browser_packages_menu"), ACTION_FILTERTYPE);
+  auto index = menu.addAction(__LOCALIZE("&All packages", "reapack_browser"), ACTION_FILTERTYPE);
   if(!m_typeFilter)
     menu.checkRadio(index);
 
@@ -353,10 +353,10 @@ void Browser::displayButton()
 
   menu.addSeparator();
 
-  menu.addAction(__LOCALIZE("&Synchronize packages", "reapack_browser_packages_menu"), ACTION_SYNCHRONIZE);
-  menu.addAction(__LOCALIZE("&Refresh repositories", "reapack_browser_packages_menu"), ACTION_REFRESH);
-  menu.addAction(__LOCALIZE("Package &editor", "reapack_browser_packages_menu"), ACTION_UPLOAD);
-  menu.addAction(__LOCALIZE("&Manage repositories...", "reapack_browser_packages_menu"), ACTION_MANAGE);
+  menu.addAction(__LOCALIZE("&Synchronize packages", "reapack_browser"), ACTION_SYNCHRONIZE);
+  menu.addAction(__LOCALIZE("&Refresh repositories", "reapack_browser"), ACTION_REFRESH);
+  menu.addAction(__LOCALIZE("Package &editor", "reapack_browser"), ACTION_UPLOAD);
+  menu.addAction(__LOCALIZE("&Manage repositories...", "reapack_browser"), ACTION_MANAGE);
 
   menu.show(m_displayBtn, handle());
 }
@@ -448,8 +448,8 @@ void Browser::refresh(const bool stale)
       show();
 
       Win32::messageBox(handle(), __LOCALIZE("No repository enabled!\n"
-        "Enable or import repositories from Extensions > ReaPack > Manage repositories.", "reapack_browser_error_msg"),
-        __LOCALIZE("Browse packages", "reapack_browser_error_msg"), MB_OK);
+        "Enable or import repositories from Extensions > ReaPack > Manage repositories.", "reapack_browser"),
+        __LOCALIZE("Browse packages", "reapack_browser"), MB_OK);
     }
 
     // Clear the list if it were previously filled.
@@ -660,8 +660,8 @@ void Browser::installLatestAll()
     const int btn = Win32::messageBox(handle(), __LOCALIZE("Do you want ReaPack to install"
       " new packages automatically when synchronizing in the future?\n\nThis"
       " setting can also be customized globally or on a per-repository basis"
-      " in ReaPack > Manage repositories.", "reapack_browser_msg"),
-      __LOCALIZE("Install every available packages", "reapack_browser_msg"), MB_YESNOCANCEL);
+      " in ReaPack > Manage repositories.", "reapack_browser"),
+      __LOCALIZE("Install every available packages", "reapack_browser"), MB_YESNOCANCEL);
 
     switch(btn) {
     case IDYES:
@@ -856,9 +856,9 @@ bool Browser::confirm() const
 
   return IDYES == Win32::messageBox(handle(), String::format(
     __LOCALIZE("Are you sure to uninstall %zu package%s?\nThe files and settings will"
-    " be permanently deleted from this computer.", "reapack_browser_uninstall_msg"),
+    " be permanently deleted from this computer.", "reapack_browser"),
     count, count == 1 ? "" : "s"
-  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_browser_uninstall_msg"), MB_YESNO);
+  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_browser"), MB_YESNO);
 }
 
 bool Browser::apply()

--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -31,6 +31,8 @@
 
 #include <algorithm>
 
+#include <WDL/localize/localize.h>
+
 enum Timers { TIMER_FILTER = 1, TIMER_ABOUT };
 
 Browser::Browser()
@@ -50,23 +52,23 @@ void Browser::onInit()
   disable(m_actionsBtn);
 
   // don't forget to update order of enum View in header file
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("All"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("Queued"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("Installed"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("Out of date"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("Obsolete"));
-  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)L("Uninstalled"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("All", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Queued", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Installed", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Out of date", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Obsolete", "reapack_browser_display_dropdown"));
+  SendMessage(m_view, CB_ADDSTRING, 0, (LPARAM)__LOCALIZE("Uninstalled", "reapack_browser_display_dropdown"));
   SendMessage(m_view, CB_SETCURSEL, 0, 0);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {"Status",       23, ListView::NoLabelFlag},
-    {"Package",     345, ListView::FilterFlag},
-    {"Category",    105, ListView::FilterFlag},
-    {"Version",      55, 0, ListView::VersionType},
-    {"Author",       95, ListView::FilterFlag},
-    {"Type",         70},
-    {"Repository",  120, ListView::CollapseFlag | ListView::FilterFlag},
-    {"Last Update", 105, 0, ListView::TimeType},
+    {__LOCALIZE("Status", "reapack_browser_column"),       23, ListView::NoLabelFlag},
+    {__LOCALIZE("Package", "reapack_browser_column"),     345, ListView::FilterFlag},
+    {__LOCALIZE("Category", "reapack_browser_column"),    105, ListView::FilterFlag},
+    {__LOCALIZE("Version", "reapack_browser_column"),      55, 0, ListView::VersionType},
+    {__LOCALIZE("Author", "reapack_browser_column"),       95, ListView::FilterFlag},
+    {__LOCALIZE("Type", "reapack_browser_column"),         70},
+    {__LOCALIZE("Repository", "reapack_browser_column"),  120, ListView::CollapseFlag | ListView::FilterFlag},
+    {__LOCALIZE("Last Update", "reapack_browser_column"), 105, 0, ListView::TimeType},
   });
 
   m_list->onActivate >> [=] { aboutPackage(m_list->itemUnderMouse()); };
@@ -264,8 +266,8 @@ bool Browser::fillContextMenu(Menu &menu, const int index)
   m_currentIndex = index;
   fillMenu(menu);
 
-  menu.addAction("&Select all", IDC_SELECT);
-  menu.addAction("&Unselect all", IDC_UNSELECT);
+  menu.addAction(__LOCALIZE("&Select all", "reapack_browser_menu"), IDC_SELECT);
+  menu.addAction(__LOCALIZE("&Unselect all", "reapack_browser_menu"), IDC_UNSELECT);
 
   return true;
 }
@@ -279,7 +281,7 @@ void Browser::fillMenu(Menu &menu)
 
     if(entry) {
       menu.addSeparator();
-      Menu pkgMenu = menu.addMenu("Package under cursor");
+      Menu pkgMenu = menu.addMenu(__LOCALIZE("Package under cursor", "reapack_browser_multiselected"));
       entry->fillMenu(pkgMenu);
     }
   }
@@ -290,7 +292,7 @@ void Browser::fillMenu(Menu &menu)
     menu.addSeparator();
 
   if(m_list->hasSelection())
-    menu.addAction("&Copy package name", ACTION_COPY);
+    menu.addAction(__LOCALIZE("&Copy package name", "reapack_browser_menu"), ACTION_COPY);
 }
 
 void Browser::fillSelectionMenu(Menu &menu)
@@ -301,18 +303,18 @@ void Browser::fillSelectionMenu(Menu &menu)
     selFlags |= getEntry(index)->possibleActions(false);
 
   menu.setEnabled(selFlags & Entry::CanInstallLatest,
-    menu.addAction("&Install/update selection", ACTION_LATEST_ALL));
+    menu.addAction(__LOCALIZE("&Install/update selection", "reapack_browser_menu"), ACTION_LATEST_ALL));
   menu.setEnabled(selFlags & Entry::CanReinstall,
-    menu.addAction("&Reinstall selection", ACTION_REINSTALL_ALL));
+    menu.addAction(__LOCALIZE("&Reinstall selection", "reapack_browser_menu"), ACTION_REINSTALL_ALL));
   menu.setEnabled(selFlags & Entry::CanUninstall,
-    menu.addAction("&Uninstall selection", ACTION_UNINSTALL_ALL));
+    menu.addAction(__LOCALIZE("&Uninstall selection", "reapack_browser_menu"), ACTION_UNINSTALL_ALL));
   menu.setEnabled(selFlags & Entry::CanClearQueued,
-    menu.addAction("&Clear queued actions", ACTION_RESET_ALL));
+    menu.addAction(__LOCALIZE("&Clear queued actions", "reapack_browser_menu"), ACTION_RESET_ALL));
 }
 
 void Browser::updateDisplayLabel()
 {
-  Win32::setWindowText(m_displayBtn, String::format("%s/%s package%s...",
+  Win32::setWindowText(m_displayBtn, String::format(__LOCALIZE("%s/%s package%s...", "reapack_browser_button"), 
     String::number(m_list->visibleRowCount()).c_str(),
     String::number(m_entries.size()).c_str(), m_entries.size() == 1 ? "" : "s"
   ).c_str());
@@ -320,25 +322,25 @@ void Browser::updateDisplayLabel()
 
 void Browser::displayButton()
 {
-  constexpr std::pair<const char *, Package::Type> types[] {
-    {"&Automation Items",  Package::AutomationItemType},
-    {"&Effects",           Package::EffectType},
-    {"E&xtensions",        Package::ExtensionType},
-    {"&Key Maps",          Package::KeymapType},
-    {"&Language Packs",    Package::LangPackType},
-    {"&MIDI Note Names",   Package::MIDINoteNamesType},
-    {"&Project Templates", Package::ProjectTemplateType},
-    {"&Scripts",           Package::ScriptType},
-    {"&Themes",            Package::ThemeType},
-    {"&Track Templates",   Package::TrackTemplateType},
-    {"&Web Interfaces",    Package::WebInterfaceType},
+  static const std::pair<const char *, Package::Type> types[] {
+    {__LOCALIZE("&Automation Items", "reapack_browser_packages_menu"),  Package::AutomationItemType},
+    {__LOCALIZE("&Effects", "reapack_browser_packages_menu"),           Package::EffectType},
+    {__LOCALIZE("E&xtensions", "reapack_browser_packages_menu"),        Package::ExtensionType},
+    {__LOCALIZE("&Key Maps", "reapack_browser_packages_menu"),          Package::KeymapType},
+    {__LOCALIZE("&Language Packs", "reapack_browser_packages_menu"),    Package::LangPackType},
+    {__LOCALIZE("&MIDI Note Names", "reapack_browser_packages_menu"),   Package::MIDINoteNamesType},
+    {__LOCALIZE("&Project Templates", "reapack_browser_packages_menu"), Package::ProjectTemplateType},
+    {__LOCALIZE("&Scripts", "reapack_browser_packages_menu"),           Package::ScriptType},
+    {__LOCALIZE("&Themes", "reapack_browser_packages_menu"),            Package::ThemeType},
+    {__LOCALIZE("&Track Templates", "reapack_browser_packages_menu"),   Package::TrackTemplateType},
+    {__LOCALIZE("&Web Interfaces", "reapack_browser_packages_menu"),    Package::WebInterfaceType},
 
-    {"&Other packages",    Package::UnknownType},
+    {__LOCALIZE("&Other packages", "reapack_browser_packages_menu"),    Package::UnknownType},
   };
 
   Menu menu;
 
-  auto index = menu.addAction("&All packages", ACTION_FILTERTYPE);
+  auto index = menu.addAction(__LOCALIZE("&All packages", "reapack_browser_packages_menu"), ACTION_FILTERTYPE);
   if(!m_typeFilter)
     menu.checkRadio(index);
 
@@ -351,10 +353,10 @@ void Browser::displayButton()
 
   menu.addSeparator();
 
-  menu.addAction("&Synchronize packages", ACTION_SYNCHRONIZE);
-  menu.addAction("&Refresh repositories", ACTION_REFRESH);
-  menu.addAction("Package &editor", ACTION_UPLOAD);
-  menu.addAction("&Manage repositories...", ACTION_MANAGE);
+  menu.addAction(__LOCALIZE("&Synchronize packages", "reapack_browser_packages_menu"), ACTION_SYNCHRONIZE);
+  menu.addAction(__LOCALIZE("&Refresh repositories", "reapack_browser_packages_menu"), ACTION_REFRESH);
+  menu.addAction(__LOCALIZE("Package &editor", "reapack_browser_packages_menu"), ACTION_UPLOAD);
+  menu.addAction(__LOCALIZE("&Manage repositories...", "reapack_browser_packages_menu"), ACTION_MANAGE);
 
   menu.show(m_displayBtn, handle());
 }
@@ -445,9 +447,9 @@ void Browser::refresh(const bool stale)
     if(!isVisible() || stale) {
       show();
 
-      Win32::messageBox(handle(), "No repository enabled!\n"
-        "Enable or import repositories from Extensions > ReaPack > Manage repositories.",
-        "Browse packages", MB_OK);
+      Win32::messageBox(handle(), __LOCALIZE("No repository enabled!\n"
+        "Enable or import repositories from Extensions > ReaPack > Manage repositories.", "reapack_browser_error_msg"),
+        __LOCALIZE("Browse packages", "reapack_browser_error_msg"), MB_OK);
     }
 
     // Clear the list if it were previously filled.
@@ -655,11 +657,11 @@ void Browser::installLatestAll()
   const bool isEverything = static_cast<size_t>(m_list->selectionSize()) == m_entries.size();
 
   if(isEverything && !installOpts.autoInstall) {
-    const int btn = Win32::messageBox(handle(), "Do you want ReaPack to install"
+    const int btn = Win32::messageBox(handle(), __LOCALIZE("Do you want ReaPack to install"
       " new packages automatically when synchronizing in the future?\n\nThis"
       " setting can also be customized globally or on a per-repository basis"
-      " in ReaPack > Manage repositories.",
-      "Install every available packages", MB_YESNOCANCEL);
+      " in ReaPack > Manage repositories.", "reapack_browser_msg"),
+      __LOCALIZE("Install every available packages", "reapack_browser_msg"), MB_YESNOCANCEL);
 
     switch(btn) {
     case IDYES:
@@ -853,10 +855,10 @@ bool Browser::confirm() const
     return true;
 
   return IDYES == Win32::messageBox(handle(), String::format(
-    "Are you sure to uninstall %zu package%s?\nThe files and settings will"
-    " be permanently deleted from this computer.",
+    __LOCALIZE("Are you sure to uninstall %zu package%s?\nThe files and settings will"
+    " be permanently deleted from this computer.", "reapack_browser_uninstall_msg"),
     count, count == 1 ? "" : "s"
-  ).c_str(), "ReaPack Query", MB_YESNO);
+  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_browser_uninstall_msg"), MB_YESNO);
 }
 
 bool Browser::apply()

--- a/src/browser_entry.cpp
+++ b/src/browser_entry.cpp
@@ -24,6 +24,7 @@
 #include "string.hpp"
 
 #include <boost/range/adaptor/reversed.hpp>
+#include <WDL/localize/localize.h>
 
 Browser::Entry::Entry(const Package *pkg, const Registry::Entry &re, const IndexPtr &i)
   : m_flags(0), regEntry(re), package(pkg), index(i), current(nullptr)
@@ -176,14 +177,14 @@ void Browser::Entry::fillMenu(Menu &menu) const
 {
   if(test(InstalledFlag)) {
     if(test(OutOfDateFlag)) {
-      const UINT actionIndex = menu.addAction(String::format("U&pdate to v%s",
+      const UINT actionIndex = menu.addAction(String::format(__LOCALIZE("U&pdate to v%s", "reapack_browser_entry"),
         latest->name().toString().c_str()), ACTION_LATEST);
 
       if(target && *target == latest)
         menu.check(actionIndex);
     }
 
-    const UINT actionIndex = menu.addAction(String::format("&Reinstall v%s",
+    const UINT actionIndex = menu.addAction(String::format(__LOCALIZE("&Reinstall v%s", "reapack_browser_entry"),
       regEntry.version.toString().c_str()), ACTION_REINSTALL);
 
     if(!current || test(ObsoleteFlag))
@@ -192,13 +193,13 @@ void Browser::Entry::fillMenu(Menu &menu) const
       menu.check(actionIndex);
   }
   else {
-    const UINT actionIndex = menu.addAction(String::format("&Install v%s",
+    const UINT actionIndex = menu.addAction(String::format(__LOCALIZE("&Install v%s", "reapack_browser_entry"),
       latest->name().toString().c_str()), ACTION_LATEST);
     if(target && *target == latest)
       menu.check(actionIndex);
   }
 
-  Menu versionMenu = menu.addMenu("Versions");
+  Menu versionMenu = menu.addMenu(__LOCALIZE("Versions", "reapack_browser_entry"));
   const UINT versionMenuIndex = menu.size() - 1;
   if(test(ObsoleteFlag))
     menu.disable(versionMenuIndex);
@@ -217,19 +218,19 @@ void Browser::Entry::fillMenu(Menu &menu) const
     }
   }
 
-  const UINT pinIndex = menu.addAction("&Pin current version", ACTION_PIN);
+  const UINT pinIndex = menu.addAction(__LOCALIZE("&Pin current version", "reapack_browser_entry"), ACTION_PIN);
   if(!test(CanToggleFlags))
     menu.disable(pinIndex);
   if(flags.value_or(regEntry.flags) & Registry::Entry::PinnedFlag)
     menu.check(pinIndex);
 
-  const UINT presIndex = menu.addAction("Enable pre-releases (&bleeding-edge)", ACTION_BLEEDINGEDGE);
+  const UINT presIndex = menu.addAction(__LOCALIZE("Enable pre-releases (&bleeding-edge)", "reapack_browser_entry"), ACTION_BLEEDINGEDGE);
   if(!test(CanToggleFlags))
     menu.disable(presIndex);
   if(flags.value_or(regEntry.flags) & Registry::Entry::BleedingEdgeFlag)
     menu.check(presIndex);
 
-  const UINT uninstallIndex = menu.addAction("&Uninstall", ACTION_UNINSTALL);
+  const UINT uninstallIndex = menu.addAction(__LOCALIZE("&Uninstall", "reapack_browser_entry"), ACTION_UNINSTALL);
   if(!test(InstalledFlag) || test(ProtectedFlag))
     menu.disable(uninstallIndex);
   else if(target && *target == nullptr)
@@ -238,9 +239,9 @@ void Browser::Entry::fillMenu(Menu &menu) const
   menu.addSeparator();
 
   menu.setEnabled(!test(ObsoleteFlag),
-    menu.addAction("About this &package", ACTION_ABOUT_PKG));
+    menu.addAction(__LOCALIZE("About this &package", "reapack_browser_entry"), ACTION_ABOUT_PKG));
 
-  menu.addAction(String::format("&About %s", indexName().c_str()), ACTION_ABOUT_REMOTE);
+  menu.addAction(String::format(__LOCALIZE("&About %s", "reapack_browser_entry"), indexName().c_str()), ACTION_ABOUT_REMOTE);
 }
 
 int Browser::Entry::possibleActions(bool allowToggle) const

--- a/src/buildlangpack.cpp
+++ b/src/buildlangpack.cpp
@@ -1,0 +1,727 @@
+// Code from https://github.com/reaper-oss/sws/blob/master/BuildUtils/BuildLangpack.cpp
+// To generate a template language pack, use:
+// buildlangpack --template src/*.cpp src/*.rc > ReaPack_template.ReaperLangPack
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+#ifndef _WIN32
+#define stricmp strcasecmp
+#endif
+
+#include <WDL/wdltypes.h>
+#include <WDL/assocarray.h>
+#include <WDL/ptrlist.h>
+#include <WDL/wdlstring.h>
+#include <WDL/fnv64.h>
+
+// Include the safe character handling functions
+static int toupper_safe(int v) { return v >= 0 && v < 256 ? toupper(v) : v; }
+static int tolower_safe(int v) { return v >= 0 && v < 256 ? tolower(v) : v; }
+static int isalnum_safe(int v) { return v >= 0 && v < 256 && isalnum(v); }
+
+static bool isblank(char c)
+{
+  return c==' ' || c== '\t' || c=='\r' || c=='\n';
+}
+static bool isblankorz(char c)
+{
+  return !c || isblank(c);
+}
+
+WDL_StringKeyedArray<char *> section_descs;
+
+WDL_StringKeyedArray< WDL_PtrList<char> * > translations;
+WDL_StringKeyedArray< WDL_StringKeyedArray<bool> * > translations_indexed;
+
+void gotString(const char *str, int len, const char *secname, bool isRC, const char *fn, int line)
+{
+  WDL_PtrList<char> *sec=translations.Get(secname);
+  if (!sec)
+  {
+    sec=new WDL_PtrList<char>;
+    translations.Insert(secname,sec);
+  }
+  WDL_StringKeyedArray<bool> *sec2 = translations_indexed.Get(secname);
+  if (!sec2)
+  {
+    sec2 = new WDL_StringKeyedArray<bool>(true);
+    translations_indexed.Insert(secname,sec2);
+  }
+  if (len > (int)strlen(str))
+  {
+    fprintf(stderr,"gotString got len>strlen(str) on %s:%d\n",fn,line);
+    exit(1);
+  }
+
+  WDL_FastString buf;
+  if (!isRC)
+  {
+    int st = 0;
+    for (int x = 0; x < len; x ++)
+    {
+      if (!st)
+      {
+        if (str[x] == '\\' && str[x+1])
+        {
+          buf.Append(str+x,2);
+          x++;
+        }
+        else if (str[x] == '\"') st=1;
+        else buf.Append(str+x,1);
+      }
+      else if (str[x] == '\"') st=0;
+      else if (!isblank(str[x]))
+      {
+        fprintf(stderr,"gotString has junk between concatenated strings on %s:%d\n",fn,line);
+        exit(1);
+      }
+    }
+  }
+  else
+  {
+    buf.Set(str,len);
+  }
+  if (sec2->Get(buf.Get())) return; //already in list
+
+  sec2->Insert(buf.Get(),true);
+  sec->Add(strdup(buf.Get()));
+}
+
+const char *g_last_file;
+int g_last_linecnt;
+
+int length_of_quoted_string(char *p, bool convertRCquotesToSlash)
+{
+  int l=0;
+  while (p[l])
+  {
+    if (convertRCquotesToSlash && p[l] == '\"' && p[l+1] == '\"')  p[l]='\\';
+
+    if (p[l] == '\"')
+    {
+      if (convertRCquotesToSlash) return l;
+
+      // scan over whitespace to see if another string begins, concat them
+      int l2 = l+1;
+      while (isblank(p[l2])) l2++;
+      if (p[l2] != '\"') return l;
+      l = l2;
+    }
+    if (p[l] == '\\')
+    {
+      l++;
+    }
+    if (!p[l] || p[l] == '\r' || p[l] == '\n') break;
+    l++;
+  }
+  fprintf(stderr,"ERROR: mismatched quotes in file %s:%d, check input!\n",g_last_file,g_last_linecnt);
+  exit(1);
+  return -1;
+}
+
+#define HACK_WILDCARD_ENTRY 2
+
+static int isLocalizeCall(const char *p)
+{
+  int rv = 0;
+  if (!strncmp(p,"__LOCALIZE",10)) { p+=10; rv = 1; }
+  else if (!strncmp(p,"ADD_WILDCARD_ENTRY",18)) { p+=18; rv = HACK_WILDCARD_ENTRY; }
+  else return 0;
+
+  if (*p == '_') while (*p == '_' || (*p >= 'A'  && *p <= 'Z')||(*p>='0' && *p <='9')) p++;
+  while (isblank(*p)) p++;
+  return *p == '(' ? rv : 0;
+}
+
+WDL_UINT64 outputLine(const char *strv, int casemode)
+{
+  WDL_UINT64 h = WDL_FNV64_IV;
+  const char *p=strv;
+  while (*p)
+  {
+    char c = *p++;
+    if (c == '\\')
+    {
+      if (*p == '\\'||*p == '"' || *p == '\'') h=WDL_FNV64(h,(unsigned char *)p,1);
+      else if (*p == 'n') h=WDL_FNV64(h,(unsigned char *)"\n",1);
+      else if (*p == 'r') h=WDL_FNV64(h,(unsigned char *)"\r",1);
+      else if (*p == 't') h=WDL_FNV64(h,(unsigned char *)"\t",1);
+      else if (*p == '0') h=WDL_FNV64(h,(unsigned char *)"",1);
+      else if (*p == 'x' && p[1] == 'e' && p[2] == '9')
+      {
+        h=WDL_FNV64(h,(unsigned char *)"\xe9",1);
+        p+=2;
+      }
+      else if (*p == 'x' && isalnum_safe(p[1]) && isalnum_safe(p[2]))
+      {
+        // Handle \x## escape sequences
+        h=WDL_FNV64(h,(unsigned char *)p,3);
+        p+=2;
+      }
+      else
+      {
+        fprintf(stderr,"ERROR: unknown escape seq in '%s' at '%s'\n",strv,p);
+        exit(1);
+      }
+      p++;
+    }
+    else h=WDL_FNV64(h,(unsigned char *)&c,1);
+  }
+  h=WDL_FNV64(h,(unsigned char *)"",1);
+
+  printf("%08X%08X=",(int)(h>>32),(int)(h&0xffffffff));
+  int lc = 0;
+  while (*strv)
+  {
+    int c = *strv++;
+    if (lc == '%' || lc == '\\') { /* hacky*/ }
+    else if (c == '\\' && strv[0] == 'x' && strv[1] == 'e' && strv[2] == '9')
+    {
+      strv+=3;
+      // encode 0xe9 as utf-8
+      printf("%c",0xc3);
+      c = 0xa9;
+    }
+    else if (casemode == 2)
+    {
+      switch (tolower_safe(c))
+      {
+        case 'o': c='0'; break;
+        case 'i': c='1'; break;
+        case 'e': c='3'; break;
+        case 'a': c='4'; break;
+        case 's': c='5'; break;
+      }
+    }
+    else if (casemode==-1) c=tolower_safe(c);
+    else if (casemode==1) c=toupper_safe(c);
+    else if (casemode==4)
+    {
+      switch (c)
+      {
+        case 'E': c=0xc494; break;
+        case 'A': c=0xc381; break;
+        case 'I': c=0xc38f; break;
+        case 'N': c=0xc391; break;
+        case 'O': c=0xc395; break;
+        case 'U': c=0xc39a; break;
+        case 'B': c=0xc39f; break;
+        case 'C': c=0xc486; break;
+        case 'G': c=0xc4a0; break;
+        case 'e': c=0xc497; break;
+        case 'a': c=0xc3a4; break;
+        case 'i': c=0xc4ad; break;
+        case 'n': c=0xc584; break;
+        case 'o': c=0xc58d; break;
+        case 'u': c=0xc5af; break;
+        case 'b': c=0xc39e; break;
+        case 'c': c=0xc48d; break;
+        case 'g': c=0xc49f; break;
+      }
+      if (c >= 256)
+      {
+        printf("%c",(c>>8));
+        c&=0xff;
+      }
+    }
+    printf("%c",c);
+    if (lc == '%' && (c == '.' || c=='l' || (c>='0' && c<='9')))
+    {
+      // ignore .xyz and l between format spec (hacky)
+    }
+    else if (lc == '%' && c == '%') lc = 0;
+    else if (lc == '\\' && c == '\\') lc = 0;
+    else lc = c;
+  }
+  printf("\n");
+  return h;
+}
+
+WDL_StringKeyedArray<int> g_resdefs;
+
+const char *getResourceDefinesFromHeader(const char *fn)
+{
+  g_resdefs.DeleteAll();
+
+  FILE *fp=fopen(fn,"rb");
+  if (!fp) return "error opening header";
+  for (;;)
+  {
+    char buf[8192];
+    g_last_linecnt++;
+    if (!fgets(buf,sizeof(buf),fp)) break;
+    char *p = buf;
+    while (*p) p++;
+    while (p>buf && (p[-1] == '\r'|| p[-1] == '\n' || p[-1] == ' ')) p--;
+    *p=0;
+
+    if (!strncmp(buf,"#define",7))
+    {
+      p=buf;
+      while (*p && *p != ' '&& *p != '\t') p++;
+      while (*p == ' ' || *p == '\t') p++;
+      char *n1 = p;
+      while (*p && *p != ' '&& *p != '\t') p++;
+      if (*p) *p++=0;
+      while (*p == ' ' || *p == '\t') p++;
+      int a = atoi(p);
+      if (a && *n1)
+      {
+        g_resdefs.Insert(n1,a);
+      }
+    }
+  }
+
+  fclose(fp);
+  return NULL;
+}
+
+void processRCfile(FILE *fp, const char *dirprefix, const char *filename)
+{
+  char sname[512];
+  sname[0]=0;
+  int depth=0;
+  for (;;)
+  {
+    char buf[8192];
+    g_last_linecnt++;
+    if (!fgets(buf,sizeof(buf),fp)) break;
+    char *p = buf;
+    while (*p) p++;
+    while (p>buf && (p[-1] == '\r'|| p[-1] == '\n' || p[-1] == ' ')) p--;
+    *p=0;
+
+    p=buf;
+    if (sname[0]) while (*p == ' ' || *p == '\t') p++;
+    char *first_tok = p;
+    if (!strncmp(first_tok,"CLASS",5) && isblank(first_tok[5]) && first_tok[6]=='\"') continue;
+
+    while (*p && *p != '\t' && *p != ' ') p++;
+    if (*p) *p++=0;
+    while (*p == '\t' || *p == ' ') p++;
+    char *second_tok = p;
+
+    if ((!strncmp(second_tok,"DIALOG",6) && isblankorz(second_tok[6])) ||
+        (!strncmp(second_tok,"DIALOGEX",8) && isblankorz(second_tok[8]))||
+        (!strncmp(second_tok,"MENU",4) && isblankorz(second_tok[4])))
+    {
+      if (sname[0])
+      {
+        fprintf(stderr,"got %s inside a block\n",second_tok);
+        exit(1);
+      }
+      int sec = g_resdefs.Get(first_tok);
+      if (!sec)
+      {
+        fprintf(stderr, "unknown dialog %s\n",first_tok);
+        exit(1);
+      }
+      sprintf(sname,"%s%s%s_%d","reapack","_",second_tok[0] == 'M' ? "MENU" : "DLG",sec);
+      section_descs.Insert(sname,strdup(first_tok));
+    }
+    else if (sname[0] && *second_tok && *first_tok)
+    {
+      if (*second_tok == '"')
+      {
+        int l = length_of_quoted_string(second_tok+1,true);
+        if (l>0)
+        {
+          gotString(second_tok+1,l,sname, true, filename, g_last_linecnt);
+
+          // OSX menu support: store a 2nd string w/o \tshortcuts, strip '&' too
+          // note: relies on length_of_quoted_string() pre-conversion above
+          if (depth && strstr(sname, "MENU_"))
+          {
+            int j=0;
+            char* m=second_tok+1;
+            for(;;)
+            {
+              if (!*m || (*m == '\\' && *(m+1)=='t') || (*m=='\"' && *(m-1)!='\\')) { buf[j]=0; break; }
+              if (*m != '&') buf[j++] = *m;
+              m++;
+            }
+            if (j!=l) gotString(buf,j,sname,true, filename, g_last_linecnt);
+          }
+        }
+      }
+    }
+    else if (!strcmp(first_tok,"BEGIN"))
+    {
+      depth++;
+    }
+    else if (!strcmp(first_tok,"END"))
+    {
+      depth--;
+      if (depth<0)
+      {
+        fprintf(stderr,"extra END\n");
+        exit(1);
+      }
+      if (!depth) sname[0]=0;
+    }
+
+  }
+  if (depth!=0)
+  {
+    fprintf(stderr,"missing some ENDs at end of rc file\n");
+    exit(1);
+  }
+}
+
+void processCPPfile(FILE *fp, const char *filename)
+{
+  char clocsec[512];
+  clocsec[0]=0;
+  WDL_FastString fs;
+  for (;;)
+  {
+    char buf[8192];
+    if (!fgets(buf,sizeof(buf),fp)) break;
+    fs.Append(buf);
+  }
+
+  char *p = (char*)fs.Get();
+  char *comment_state = NULL;
+  g_last_linecnt++;
+  while (*p)
+  {
+    if (!strncmp(p,"//",2))
+    {
+      comment_state = p;
+      p+=2;
+    }
+    else if (*p == '\n')
+    {
+      g_last_linecnt++;
+      comment_state = NULL;
+      p++;
+    }
+    else if (!comment_state)
+    {
+      int hm;
+      if (*p == '\\') { p++; if (*p) p++; }
+      else if (*p == '\'') { p++; if (*p == '"') p++; }
+      else if (*p == '"')
+      {
+        int l = length_of_quoted_string(p+1,false);
+        if (clocsec[0])
+        {
+          gotString(p+1,l,clocsec,false, filename, g_last_linecnt);
+        }
+        p += l+2;
+      }
+      else if (*p == 'R' && *(p+1) == '"')
+      {
+        // Handle raw string literals (R"(...)")
+        p += 2; // Skip R"
+        // Find the delimiter
+        char *delim_start = p;
+        while (*p && *p != '(') p++;
+        if (*p == '(') {
+          int delim_len = p - delim_start;
+          p++; // Skip (
+          // Find the ending delimiter
+          char end_delim[256];
+          end_delim[0] = ')';
+          memcpy(end_delim+1, delim_start, delim_len);
+          end_delim[delim_len+1] = '"';
+          end_delim[delim_len+2] = '\0';
+          
+          char *end_pos = strstr(p, end_delim);
+          if (end_pos) {
+            int l = end_pos - p;
+            if (clocsec[0])
+            {
+              gotString(p,l,clocsec,false, filename, g_last_linecnt);
+            }
+            p = end_pos + delim_len + 2;
+          }
+        }
+      }
+      else if ((p==(char*)fs.Get() || (!isalnum_safe(p[-1]) && p[-1] != '_')) && (hm=isLocalizeCall(p)))
+      {
+        while (*p != '(') p++;
+        p++;
+        while (isblank(*p)) p++;
+        if (*p++ != '"')
+        {
+          fprintf(stderr,"Error: missing \" on %s:%d\n",filename,g_last_linecnt);
+          exit(1);
+        }
+        int l = length_of_quoted_string(p,false);
+        char *sp = p;
+        p+=l+1;
+        while (isblank(*p)) p++;
+        if (*p++ != ',')
+        {
+          fprintf(stderr,"Error: missing , on %s:%d\n",filename,g_last_linecnt);
+          exit(1);
+        }
+        while (isblank(*p)) p++;
+        if (*p++ != '"')
+        {
+          fprintf(stderr,"Error: missing second \" on %s:%d\n",filename,g_last_linecnt);
+          exit(1);
+        }
+        int l2 = length_of_quoted_string(p,false);
+
+        if (hm == HACK_WILDCARD_ENTRY)
+        {
+          gotString(p,l2,"render_wildcard",false, filename, g_last_linecnt);
+          p += l2;
+        }
+        else
+        {
+          char sec[512];
+          memcpy(sec,p,l2);
+          sec[l2]=0;
+          p+=l2;
+          gotString(sp,l,sec,false, filename, g_last_linecnt);
+        }
+        p++;
+      }
+      else
+        p++;
+    }
+    else if (p > comment_state && p < comment_state + 4)
+    {
+      if (!strncmp(p,"!WANT_LOCALIZE_STRINGS_BEGIN:",29))
+      {
+        p += 29;
+        if (clocsec[0])
+        {
+          fprintf(stderr,"Error: !WANT_LOCALIZE_STRINGS_BEGIN: before WANT_LOCALIZE_STRINGS_END on  %s:%d\n",filename,g_last_linecnt);
+          exit(1);
+        }
+        size_t a = 0;
+        while (*p && !isblank(*p) && a < sizeof(clocsec)) clocsec[a++] = *p++;
+        if (a >= sizeof(clocsec))
+        {
+          fprintf(stderr,"Error: !WANT_LOCALIZE_STRINGS_BEGIN: too long on %s:%d\n",filename,g_last_linecnt);
+          exit(1);
+        }
+        clocsec[a]=0;
+      }
+      else
+      {
+        if (!strncmp(p,"!WANT_LOCALIZE_STRINGS_END",26))
+        {
+          if (!clocsec[0])
+          {
+            fprintf(stderr,"Error: mismatched !WANT_LOCALIZE_STRINGS_END on %s:%d\n",filename,g_last_linecnt);
+            exit(1);
+          }
+          clocsec[0]=0;
+        }
+        p++;
+      }
+    }
+    else p++;
+  }
+  if (clocsec[0])
+  {
+    fprintf(stderr,"Error: missing !WANT_LOCALIZE_STRINGS_END at eof %s:%d\n",filename,g_last_linecnt);
+    exit(1);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  int x;
+  int casemode=0;
+  for (x=1;x<argc;x++)
+  {
+    if (argv[x][0] == '-')
+    {
+      if (!strcmp(argv[x],"--lower")) casemode = -1;
+      else if (!strcmp(argv[x],"--leet")) casemode = 2;
+      else if (!strcmp(argv[x],"--utf8test")) casemode = 4;
+      else if (!strcmp(argv[x],"--upper")) casemode = 1;
+      else if (!strcmp(argv[x],"--template")) casemode = 3;
+      else
+      {
+        printf("Usage: build_langpack [--leet|--lower|--upper|--template] file.rc file.cpp ...\n");
+        exit(1);
+      }
+      continue;
+    }
+    FILE *fp = fopen(argv[x],"rb");
+    if (!fp)
+    {
+      fprintf(stderr,"Error opening %s\n",argv[x]);
+      return 1;
+    }
+    g_last_file = argv[x];
+    g_last_linecnt=1;
+    int alen =strlen(argv[x]);
+    if (alen>3 && !stricmp(argv[x]+alen-3,".rc"))
+    {
+      WDL_String s(argv[x]);
+      WDL_String dpre;
+      char *p=s.Get();
+      while (*p) p++;
+      while (p>=s.Get() && *p != '\\' && *p != '/') p--;
+      *++p=0;
+      if (p>s.Get())
+      {
+        p-=2;
+        while (p>=s.Get() && *p != '\\' && *p != '/') p--;
+        dpre.Set(++p); // get dir name portion
+        if (dpre.GetLength()) dpre.Get()[dpre.GetLength()-1]=0;
+      }
+
+      s.Append("resource.hpp");
+      const char *err=getResourceDefinesFromHeader(s.Get());
+      if (err)
+      {
+        fprintf(stderr,"Error reading %s: %s\n",s.Get(),err);
+        exit(1);
+      }
+      // Use "reapack" as prefix instead of directory name
+      processRCfile(fp, "reapack", argv[x]);
+    }
+    else
+    {
+      processCPPfile(fp,argv[x]);
+    }
+
+    fclose(fp);
+  }
+
+  printf("#NAME:%s\n",
+       casemode==-1 ? "ReaPack English (lower case, demo)" :
+       casemode==1 ? "ReaPack English (upper case, demo)" :
+       casemode==2 ? "ReaPack English (leet-speak, demo)" :
+       casemode==4 ? "ReaPack UTF-8 English test (demo)" :
+       casemode==3 ? "ReaPack Template (edit-me)" :
+       "ReaPack English (sample language pack)");
+
+  if (casemode==3)
+  {
+    printf("; NOTE: this is the best starting point for making a new ReaPack langpack.\n"
+           "; As you translate a string, remove the ; from the beginning of the\n"
+           "; line. If the line begins with ;^, then it is an optional string,\n"
+           "; and you should only modify that line if the definition in [common]\n"
+           "; is not accurate for that context.\n"
+           "; You can enlarge windows using 5CA1E00000000000=scale, for example:\n"
+           "; [DLG_218] ; IDD_LOCKSETTINGS\n"
+           "; 5CA1E00000000000=1.2\n"
+           "; This makes the above dialog 1.2x wider than default.\n\n");
+  }
+
+  WDL_StringKeyedArray<bool> common_found;
+  {
+    if (!translations_indexed.GetSize())
+    {
+      fprintf(stderr,"no sections!\n");
+      exit(1);
+    }
+    else if (translations_indexed.GetSize() > 4096)
+    {
+      fprintf(stderr,"too many translation sections, check input or adjust code here\n");
+      exit(1);
+    }
+    fprintf(stderr,"%d sections\n",translations_indexed.GetSize());
+
+    int pos[4096]={0,};
+    printf("[common]\n");
+    WDL_FastString matchlist;
+    WDL_IntKeyedArray2<bool> ids;
+    int minpos = 0;
+    for (;;)
+    {
+      int matchcnt=0;
+      matchlist.Set("");
+      const char *str=NULL;
+      for(x=minpos;x<translations_indexed.GetSize();x++)
+      {
+        const char *secname;
+        WDL_StringKeyedArray<bool> *l = translations_indexed.Enumerate(x,&secname);
+        int sz=l->GetSize();
+        if (!str)
+        {
+          if (x>minpos)
+          {
+            memset(pos,0,sizeof(pos)); // start over
+            minpos=x;
+          }
+          while (!str && pos[x]<sz)
+          {
+            l->Enumerate(pos[x]++,&str);
+            if (!*str || common_found.Get(str)) str=NULL; // skip if we've already analyzed this string
+          }
+          if (str) matchlist.Set(secname);
+        }
+        else
+        {
+          while (pos[x] < sz)
+          {
+            const char *tv=NULL;
+            l->Enumerate(pos[x],&tv);
+            int c = strcmp(tv,str);
+            if (c>0) break;
+            pos[x]++;
+            if (!c)
+            {
+              matchlist.Append(", ");
+              matchlist.Append(secname);
+              matchcnt++;
+              break;
+            }
+          }
+        }
+      }
+      if (matchcnt>0)
+      {
+        common_found.Insert(str,true);
+        //printf("; used by: %s\n",matchlist.Get());
+        if (casemode==3) printf(";");
+        WDL_UINT64 a = outputLine(str,casemode);
+        if (ids.Exists(a))
+        {
+          fprintf(stderr,"duplicate hash for strings in common section, hope this is OK.. 64 bit hash fail!\n");
+          exit(1);
+        }
+//        printf("\n");
+        ids.Insert(a,true);
+      }
+      if (minpos == x-1) break;
+    }
+    printf("\n");
+  }
+
+  for(x=0;x<translations.GetSize();x++)
+  {
+    const char *nm=NULL;
+    WDL_PtrList<char> *p = translations.Enumerate(x,&nm);
+    if (x) printf("\n");
+    char *secinfo = section_descs.Get(nm);
+    printf("[%s]%s%s\n",nm,secinfo?" ; ":"", secinfo?secinfo:"");
+    int a;
+    int y;
+    WDL_IntKeyedArray2<bool> ids;
+    for (a=0;a<2;a++)
+    {
+      for (y=0;y<p->GetSize();y++)
+      {
+        char *strv=p->Get(y);
+        if (!*strv) continue;
+        if ((common_found.Get(strv)?1:0) != a) continue;
+
+        if (a) printf(";^");
+        else if (casemode==3) printf(";");
+
+        WDL_UINT64 a = outputLine(strv,casemode);
+        if (ids.Exists(a))
+        {
+          fprintf(stderr,"duplicate hash for strings in section, hope this is OK.. 64 bit hash fail!\n");
+          exit(1);
+        }
+        ids.Insert(a,true);
+      }
+    }
+  }
+  return 0;
+}

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -148,11 +148,11 @@ INT_PTR Dialog::init(REAPER_PLUGIN_HINSTANCE inst, HWND parent, Modality mode)
 
   switch(mode) {
   case Modeless:
-    CreateDialogParam(inst, MAKEINTRESOURCE(m_template),
+    CreateDialogParam(inst, reinterpret_cast<const char *>(MAKEINTRESOURCE(m_template)),
       m_parent, Proc, reinterpret_cast<LPARAM>(this));
     return true;
   case Modal:
-    return DialogBoxParam(inst, MAKEINTRESOURCE(m_template),
+    return DialogBoxParam(inst, reinterpret_cast<const char *>(MAKEINTRESOURCE(m_template)),
       m_parent, Proc, reinterpret_cast<LPARAM>(this));
   }
 

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <boost/algorithm/string/join.hpp>
 #include <reaper_plugin_functions.h>
+#include <WDL/localize/localize.h>
 
 #ifdef _WIN32
 #  include <windowsx.h>

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 
 #include <reaper_plugin_functions.h>
+#include <WDL/localize/localize.h>
 
 static const int DOWNLOAD_TIMEOUT = 15;
 // to set the amount of concurrent downloads, change the size of
@@ -115,7 +116,7 @@ Download::Download(const std::string &url, const NetworkOpts &opts, const int fl
 
 void Download::setName(const std::string &name)
 {
-  setSummary({ "Downloading", name });
+  setSummary({ __LOCALIZE("Downloading", "reapack_download"), name });
 }
 
 static bool isGitHub(const std::string &url)
@@ -176,7 +177,7 @@ bool Download::run(const bool proxy)
     headers = curl_slist_append(headers, "X-ReaPack-Proxy: 1");
   curl_easy_setopt(ctx, CURLOPT_HTTPHEADER, headers);
 
-  std::string errbuf = "No error message";
+  std::string errbuf = __LOCALIZE("No error message", "reapack_download_msg");
   errbuf.resize(CURL_ERROR_SIZE - 1, '\0');
   curl_easy_setopt(ctx, CURLOPT_ERRORBUFFER, errbuf.data());
 
@@ -204,7 +205,7 @@ bool Download::run(const bool proxy)
   }
   else if(write.hash && write.hash->digest() != m_expectedChecksum) {
     const std::string &err = String::format(
-      "Checksum mismatch.\nExpected: %s\nActual: %s",
+      __LOCALIZE("Checksum mismatch.\nExpected: %s\nActual: %s", "reapack_download_msg"),
       m_expectedChecksum.c_str(), write.hash->digest().c_str()
     );
     setError({err, m_url});

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -177,7 +177,7 @@ bool Download::run(const bool proxy)
     headers = curl_slist_append(headers, "X-ReaPack-Proxy: 1");
   curl_easy_setopt(ctx, CURLOPT_HTTPHEADER, headers);
 
-  std::string errbuf = __LOCALIZE("No error message", "reapack_download_msg");
+  std::string errbuf = __LOCALIZE("No error message", "reapack_download");
   errbuf.resize(CURL_ERROR_SIZE - 1, '\0');
   curl_easy_setopt(ctx, CURLOPT_ERRORBUFFER, errbuf.data());
 
@@ -205,7 +205,7 @@ bool Download::run(const bool proxy)
   }
   else if(write.hash && write.hash->digest() != m_expectedChecksum) {
     const std::string &err = String::format(
-      __LOCALIZE("Checksum mismatch.\nExpected: %s\nActual: %s", "reapack_download_msg"),
+      __LOCALIZE("Checksum mismatch.\nExpected: %s\nActual: %s", "reapack_download"),
       m_expectedChecksum.c_str(), write.hash->digest().c_str()
     );
     setError({err, m_url});

--- a/src/import.cpp
+++ b/src/import.cpp
@@ -28,6 +28,8 @@
 #include "transaction.hpp"
 #include "win32.hpp"
 
+#include <WDL/localize/localize.h>
+
 #include <boost/algorithm/string/trim.hpp>
 
 static const char *TITLE = "Import repositories";
@@ -138,7 +140,7 @@ void Import::fetch()
         break;
       case ThreadTask::Failure:
         Win32::messageBox(handle(), String::format(
-          "Download failed: %s\n%s", dl->error().message.c_str(), url.c_str()
+          __LOCALIZE("Download failed: %s\n%s", "reapack_error_msg"), dl->error().message.c_str(), url.c_str()
         ).c_str(), TITLE, MB_OK);
         m_pool->abort();
         break;
@@ -165,15 +167,15 @@ try {
   if(exists && remote.url() != dl->url()) {
     if(remote.isProtected()) {
       Win32::messageBox(handle(), String::format(
-        "The repository %s is protected and cannot be overwritten.",
+        __LOCALIZE("The repository %s is protected and cannot be overwritten.", "reapack_error_msg"),
         index->name().c_str()
       ).c_str(), TITLE, MB_OK);
       return false;
     }
     else {
       const auto answer = Win32::messageBox(handle(), String::format(
-        "%s is already configured with a different URL.\n"
-        "Do you want to overwrite it?", index->name().c_str()
+        __LOCALIZE("%s is already configured with a different URL.\n"
+        "Do you want to overwrite it?", "reapack_import"), index->name().c_str()
       ).c_str(), TITLE, MB_YESNO);
 
       if(answer != IDYES)
@@ -192,7 +194,7 @@ try {
 }
 catch(const reapack_error &e) {
   Win32::messageBox(handle(), String::format(
-    "The received file is invalid: %s\n%s", e.what(), dl->url().c_str()
+    __LOCALIZE("The received file is invalid: %s\n%s", "reapack_error_msg"), e.what(), dl->url().c_str()
   ).c_str(), TITLE, MB_OK);
   return false;
 }

--- a/src/import.cpp
+++ b/src/import.cpp
@@ -140,7 +140,7 @@ void Import::fetch()
         break;
       case ThreadTask::Failure:
         Win32::messageBox(handle(), String::format(
-          __LOCALIZE("Download failed: %s\n%s", "reapack_error_msg"), dl->error().message.c_str(), url.c_str()
+          __LOCALIZE("Download failed: %s\n%s", "reapack_import"), dl->error().message.c_str(), url.c_str()
         ).c_str(), TITLE, MB_OK);
         m_pool->abort();
         break;
@@ -167,7 +167,7 @@ try {
   if(exists && remote.url() != dl->url()) {
     if(remote.isProtected()) {
       Win32::messageBox(handle(), String::format(
-        __LOCALIZE("The repository %s is protected and cannot be overwritten.", "reapack_error_msg"),
+        __LOCALIZE("The repository %s is protected and cannot be overwritten.", "reapack_import"),
         index->name().c_str()
       ).c_str(), TITLE, MB_OK);
       return false;
@@ -194,7 +194,7 @@ try {
 }
 catch(const reapack_error &e) {
   Win32::messageBox(handle(), String::format(
-    __LOCALIZE("The received file is invalid: %s\n%s", "reapack_error_msg"), e.what(), dl->url().c_str()
+    __LOCALIZE("The received file is invalid: %s\n%s", "reapack_import"), e.what(), dl->url().c_str()
   ).c_str(), TITLE, MB_OK);
   return false;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -53,13 +53,13 @@ IndexPtr Index::load(const std::string &name, const char *data)
   const XmlNode &root = doc.root();
 
   if(!root || strcmp(root.name(), "index"))
-    throw reapack_error(__LOCALIZE("invalid index", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("invalid index", "reapack_index"));
 
   int version = 0;
   root.attribute("version", &version);
 
   if(!version)
-    throw reapack_error(__LOCALIZE("index version not found", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("index version not found", "reapack_index"));
 
   Index *ri = new Index(name);
 
@@ -72,7 +72,7 @@ IndexPtr Index::load(const std::string &name, const char *data)
     loadV1(root, ri);
     break;
   default:
-    throw reapack_error(__LOCALIZE("index version is unsupported", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("index version is unsupported", "reapack_index"));
   }
 
   ptr.release();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -22,6 +22,8 @@
 #include "path.hpp"
 #include "remote.hpp"
 #include "xml.hpp"
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <cstring>
 #include <fstream>
@@ -51,13 +53,13 @@ IndexPtr Index::load(const std::string &name, const char *data)
   const XmlNode &root = doc.root();
 
   if(!root || strcmp(root.name(), "index"))
-    throw reapack_error("invalid index");
+    throw reapack_error(__LOCALIZE("invalid index", "reapack_error_msg"));
 
   int version = 0;
   root.attribute("version", &version);
 
   if(!version)
-    throw reapack_error("index version not found");
+    throw reapack_error(__LOCALIZE("index version not found", "reapack_error_msg"));
 
   Index *ri = new Index(name);
 
@@ -70,7 +72,7 @@ IndexPtr Index::load(const std::string &name, const char *data)
     loadV1(root, ri);
     break;
   default:
-    throw reapack_error("index version is unsupported");
+    throw reapack_error(__LOCALIZE("index version is unsupported", "reapack_error_msg"));
   }
 
   ptr.release();

--- a/src/install.cpp
+++ b/src/install.cpp
@@ -25,6 +25,8 @@
 #include "reapack.hpp"
 #include "transaction.hpp"
 
+#include <WDL/localize/localize.h>
+
 InstallTask::InstallTask(const Version *ver, const int flags,
     const Registry::Entry &re, const ArchiveReaderPtr &reader, Transaction *tx)
   : Task(tx), m_version(ver), m_flags(flags), m_oldEntry(std::move(re)), m_reader(reader),
@@ -44,8 +46,8 @@ bool InstallTask::start()
 
     if(!conflicts.empty()) {
       for(const Path &path : conflicts) {
-        tx()->receipt()->addError({"Conflict: " + path.join() +
-          " is already owned by another package", m_version->fullName()});
+        tx()->receipt()->addError({__LOCALIZE("Conflict: ", "reapack_error_msg") + path.join() +
+          __LOCALIZE(" is already owned by another package", "reapack_error_msg"), m_version->fullName()});
       }
 
       return false;
@@ -102,7 +104,7 @@ void InstallTask::commit()
   for(const TempPath &paths : m_newFiles) {
     if(!FS::rename(paths)) {
       tx()->receipt()->addError({
-        String::format("Cannot rename to target: %s", FS::lastError()),
+        String::format(__LOCALIZE("Cannot rename to target: %s", "reapack_error_msg"), FS::lastError()),
         paths.target().join()});
 
       // it's a bit late to rollback here as some files might already have been

--- a/src/install.cpp
+++ b/src/install.cpp
@@ -46,8 +46,8 @@ bool InstallTask::start()
 
     if(!conflicts.empty()) {
       for(const Path &path : conflicts) {
-        tx()->receipt()->addError({__LOCALIZE("Conflict: ", "reapack_error_msg") + path.join() +
-          __LOCALIZE(" is already owned by another package", "reapack_error_msg"), m_version->fullName()});
+        tx()->receipt()->addError({__LOCALIZE("Conflict: ", "reapack_install") + path.join() +
+          __LOCALIZE(" is already owned by another package", "reapack_install"), m_version->fullName()});
       }
 
       return false;
@@ -104,7 +104,7 @@ void InstallTask::commit()
   for(const TempPath &paths : m_newFiles) {
     if(!FS::rename(paths)) {
       tx()->receipt()->addError({
-        String::format(__LOCALIZE("Cannot rename to target: %s", "reapack_error_msg"), FS::lastError()),
+        String::format(__LOCALIZE("Cannot rename to target: %s", "reapack_install"), FS::lastError()),
         paths.target().join()});
 
       // it's a bit late to rollback here as some files might already have been

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -27,6 +27,8 @@
 #include <cassert>
 #include <reaper_plugin_secrets.h>
 
+#include <WDL/localize/localize.h>
+
 static int adjustWidth(const int points)
 {
 #ifdef _WIN32
@@ -606,7 +608,7 @@ void ListView::headerMenu(const int x, const int y)
   enum { ACTION_RESTORE = 800 };
 
   Menu menu;
-  menu.disable(menu.addAction("Visible columns:", 0));
+  menu.disable(menu.addAction(__LOCALIZE("Visible columns:", "reapack_listview_menu"), 0));
 
   for(int i = 0; i < columnCount(); i++) {
     const auto id = menu.addAction(m_cols[i].label.c_str(), i | (1 << 8));
@@ -616,7 +618,7 @@ void ListView::headerMenu(const int x, const int y)
   }
 
   menu.addSeparator();
-  menu.addAction("Reset columns", ACTION_RESTORE);
+  menu.addAction(__LOCALIZE("Reset columns", "reapack_listview_menu"), ACTION_RESTORE);
 
   const int cmd = menu.show(x, y, handle());
 

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -608,7 +608,7 @@ void ListView::headerMenu(const int x, const int y)
   enum { ACTION_RESTORE = 800 };
 
   Menu menu;
-  menu.disable(menu.addAction(__LOCALIZE("Visible columns:", "reapack_listview_menu"), 0));
+  menu.disable(menu.addAction(__LOCALIZE("Visible columns:", "reapack_listview"), 0));
 
   for(int i = 0; i < columnCount(); i++) {
     const auto id = menu.addAction(m_cols[i].label.c_str(), i | (1 << 8));
@@ -618,7 +618,7 @@ void ListView::headerMenu(const int x, const int y)
   }
 
   menu.addSeparator();
-  menu.addAction(__LOCALIZE("Reset columns", "reapack_listview_menu"), ACTION_RESTORE);
+  menu.addAction(__LOCALIZE("Reset columns", "reapack_listview"), ACTION_RESTORE);
 
   const int cmd = menu.show(x, y, handle());
 

--- a/src/localize-import.h
+++ b/src/localize-import.h
@@ -1,0 +1,83 @@
+// used by plug-ins to access imported localization
+// usage, in one file: 
+// #define LOCALIZE_IMPORT_PREFIX "midi_" (should be the directory name with _)
+// #include "localize-import.h"
+// #include "localize.h"
+// import function pointers in initialization
+//
+// other files can simply import localize.h as normal
+// note that if the module might be unloaded, LOCALIZE_FLAG_NOCACHE is essential!
+//
+
+#ifdef _WDL_LOCALIZE_H_
+#error you must include localize-import.h before localize.h, sorry
+#endif
+
+#include <stdio.h>
+#include "../wdltypes.h"
+
+// caller must import these 4 function pointers from the running app
+static const char *(*importedLocalizeFunc)(const char *str, const char *subctx, int flags);
+static void (*importedLocalizeMenu)(const char *rescat, HMENU hMenu, LPCSTR lpMenuName);
+static DLGPROC (*importedLocalizePrepareDialog)(const char *rescat, HINSTANCE hInstance, const char *lpTemplate, DLGPROC dlgProc, LPARAM lPAram, void **ptrs, int nptrs);
+static void (*importedLocalizeInitializeDialog)(HWND hwnd, const char *d);
+
+const char *__localizeFunc(const char *str, const char *subctx, int flags)
+{
+  if (WDL_NORMALLY(importedLocalizeFunc)) return importedLocalizeFunc(str,subctx,flags);
+  return str;
+}
+
+HMENU __localizeLoadMenu(HINSTANCE hInstance, const char *lpMenuName)
+{
+  HMENU menu = LoadMenu(hInstance,reinterpret_cast<LPCTSTR>(lpMenuName));
+  if (menu && WDL_NORMALLY(importedLocalizeMenu)) importedLocalizeMenu(LOCALIZE_IMPORT_PREFIX,menu,lpMenuName);
+  return menu;
+}
+
+HWND __localizeDialog(HINSTANCE hInstance, const char *lpTemplate, HWND hwndParent, DLGPROC dlgProc, LPARAM lParam, int mode)
+{
+  void *p[5];
+  char tmp[256];
+  if (mode == 1)
+  {
+    sprintf(tmp,"%.100s%d",LOCALIZE_IMPORT_PREFIX,(int)(INT_PTR)lpTemplate);
+    p[4] = tmp;
+  }
+  else
+    p[4] = NULL;
+
+  if (WDL_NORMALLY(importedLocalizePrepareDialog))
+  {
+    DLGPROC newDlg  = importedLocalizePrepareDialog(LOCALIZE_IMPORT_PREFIX,hInstance,lpTemplate,dlgProc,lParam,p,sizeof(p)/sizeof(p[0]));
+    if (newDlg)
+    {
+      dlgProc = newDlg;
+      lParam = (LPARAM)(INT_PTR)p;
+    }
+  }
+  switch (mode)
+  {
+    case 0: return CreateDialogParam(hInstance,reinterpret_cast<LPCTSTR>(lpTemplate),hwndParent,dlgProc,lParam);
+    case 1: return (HWND) (INT_PTR)DialogBoxParam(hInstance,reinterpret_cast<LPCTSTR>(lpTemplate),hwndParent,dlgProc,lParam);
+  }
+  return 0;
+}
+
+void __localizeInitializeDialog(HWND hwnd, const char *d)
+{
+  if (WDL_NORMALLY(importedLocalizeInitializeDialog)) importedLocalizeInitializeDialog(hwnd,d);
+}
+
+static WDL_STATICFUNC_UNUSED void localizeKbdSection(KbdSectionInfo *sec, const char *nm)
+{
+  if (WDL_NORMALLY(importedLocalizeFunc))
+  {
+    int x;
+    if (sec->action_list) for (x=0;x<sec->action_list_cnt; x++)
+    {
+      KbdCmd *p = &sec->action_list[x];
+      if (p->text) p->text = __localizeFunc(p->text,nm,2/*LOCALIZE_FLAG_NOCACHE*/);
+    }
+  }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@
 #include <reaper_plugin_secrets.h>
 
 #define LOCALIZE_IMPORT_PREFIX "reapack_"
-#include <WDL/localize/localize-import.h>
+#include "localize-import.h"
 #include <WDL/localize/localize.h>
 
 #define REQUIRED_API(name) {reinterpret_cast<void **>(&name), #name, true}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,9 +62,9 @@ static bool loadAPI(void *(*getFunc)(const char *))
     if(func.required && *func.ptr == nullptr) {
       Win32::messageBox(Splash_GetWnd ? Splash_GetWnd() : nullptr, String::format(
         __LOCALIZE("ReaPack v%s is incompatible with this version of REAPER.\n\n"
-        "(Unable to import the following API function: %s)", "reapack_error_msg"),
+        "(Unable to import the following API function: %s)", "reapack_main"),
         REAPACK_VERSION, func.name
-      ).c_str(), __LOCALIZE("ReaPack: Missing REAPER feature", "reapack_error_msg"), MB_OK);
+      ).c_str(), __LOCALIZE("ReaPack: Missing REAPER feature", "reapack_main"), MB_OK);
 
       return false;
     }
@@ -89,13 +89,13 @@ static void menuHook(const char *name, HMENU handle, const int f)
   if(strcmp(name, "Main extensions") || f != 0)
     return;
 
-  Menu menu = Menu(handle).addMenu(__LOCALIZE("Rea&Pack", "reapack_main_menu"));
-  menu.addAction(__LOCALIZE("&Synchronize packages", "reapack_main_menu"),   "_REAPACK_SYNC");
-  menu.addAction(__LOCALIZE("&Browse packages...", "reapack_main_menu"),     "_REAPACK_BROWSE");
-  menu.addAction(__LOCALIZE("&Import repositories...", "reapack_main_menu"), "_REAPACK_IMPORT");
-  menu.addAction(__LOCALIZE("&Manage repositories...", "reapack_main_menu"), "_REAPACK_MANAGE");
+  Menu menu = Menu(handle).addMenu(__LOCALIZE("Rea&Pack", "reapack_main"));
+  menu.addAction(__LOCALIZE("&Synchronize packages", "reapack_main"),   "_REAPACK_SYNC");
+  menu.addAction(__LOCALIZE("&Browse packages...", "reapack_main"),     "_REAPACK_BROWSE");
+  menu.addAction(__LOCALIZE("&Import repositories...", "reapack_main"), "_REAPACK_IMPORT");
+  menu.addAction(__LOCALIZE("&Manage repositories...", "reapack_main"), "_REAPACK_MANAGE");
   menu.addSeparator();
-  menu.addAction(String::format(__LOCALIZE("&About ReaPack v%s", "reapack_main_menu"), REAPACK_VERSION), "_REAPACK_ABOUT");
+  menu.addAction(String::format(__LOCALIZE("&About ReaPack v%s", "reapack_main"), REAPACK_VERSION), "_REAPACK_ABOUT");
 }
 
 static bool checkLocation(REAPER_PLUGIN_HINSTANCE module)
@@ -126,9 +126,9 @@ static bool checkLocation(REAPER_PLUGIN_HINSTANCE module)
     __LOCALIZE("ReaPack was not loaded from the standard extension path"
     " or its filename was altered.\n"
     "Move or rename it to the expected location and retry.\n\n"
-    "Current: %s\n\nExpected: %s", "reapack_error_msg"),
+    "Current: %s\n\nExpected: %s", "reapack_main"),
     current.join().c_str(), expected.join().c_str()
-  ).c_str(), __LOCALIZE("ReaPack: Installation path mismatch", "reapack_error_msg"), MB_OK);
+  ).c_str(), __LOCALIZE("ReaPack: Installation path mismatch", "reapack_main"), MB_OK);
 
   return false;
 }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -69,8 +69,8 @@ void Manager::onInit()
   disable(m_apply);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {__LOCALIZE("Name", "reapack_manager_column"), 155},
-    {__LOCALIZE("Index URL", "reapack_manager_column"), 435},
+    {__LOCALIZE("Name", "reapack_manager"), 155},
+    {__LOCALIZE("Index URL", "reapack_manager"), 435},
   });
 
   m_list->enableIcons();
@@ -213,28 +213,28 @@ bool Manager::fillContextMenu(Menu &menu, const int index) const
   const Remote &remote = getRemote(index);
 
   if(!remote) {
-    menu.addAction(__LOCALIZE("&Select all", "reapack_manager_menu"), ACTION_SELECT);
-    menu.addAction(__LOCALIZE("&Unselect all", "reapack_manager_menu"), ACTION_UNSELECT);
+    menu.addAction(__LOCALIZE("&Select all", "reapack_manager"), ACTION_SELECT);
+    menu.addAction(__LOCALIZE("&Unselect all", "reapack_manager"), ACTION_UNSELECT);
     return true;
   }
 
-  menu.addAction(__LOCALIZE("&Refresh", "reapack_manager_menu"), ACTION_REFRESH);
-  menu.addAction(__LOCALIZE("&Copy URL", "reapack_manager_menu"), ACTION_COPYURL);
+  menu.addAction(__LOCALIZE("&Refresh", "reapack_manager"), ACTION_REFRESH);
+  menu.addAction(__LOCALIZE("&Copy URL", "reapack_manager"), ACTION_COPYURL);
 
-  Menu autoInstallMenu = menu.addMenu(__LOCALIZE("&Install new packages", "reapack_manager_menu"));
+  Menu autoInstallMenu = menu.addMenu(__LOCALIZE("&Install new packages", "reapack_manager"));
   const UINT autoInstallGlobal = autoInstallMenu.addAction(
-    __LOCALIZE("Use &global setting", "reapack_manager_menu"), ACTION_AUTOINSTALL_GLOBAL);
+    __LOCALIZE("Use &global setting", "reapack_manager"), ACTION_AUTOINSTALL_GLOBAL);
   const UINT autoInstallOff = autoInstallMenu.addAction(
-    __LOCALIZE("Manually", "reapack_manager_menu"), ACTION_AUTOINSTALL_OFF);
+    __LOCALIZE("Manually", "reapack_manager"), ACTION_AUTOINSTALL_OFF);
   const UINT autoInstallOn = autoInstallMenu.addAction(
-    __LOCALIZE("When synchronizing", "reapack_manager_menu"), ACTION_AUTOINSTALL_ON);
+    __LOCALIZE("When synchronizing", "reapack_manager"), ACTION_AUTOINSTALL_ON);
 
   const UINT uninstallAction =
-    menu.addAction(__LOCALIZE("&Uninstall", "reapack_manager_menu"), ACTION_UNINSTALL);
+    menu.addAction(__LOCALIZE("&Uninstall", "reapack_manager"), ACTION_UNINSTALL);
 
   menu.addSeparator();
 
-  menu.addAction(String::format(__LOCALIZE("&About %s", "reapack_manager_menu"), remote.name().c_str()),
+  menu.addAction(String::format(__LOCALIZE("&About %s", "reapack_manager"), remote.name().c_str()),
     index | (ACTION_ABOUT << 8));
 
   bool allProtected = true;
@@ -472,10 +472,10 @@ void Manager::aboutRepo(const bool focus)
 void Manager::importExport()
 {
   Menu menu;
-  menu.addAction(__LOCALIZE("Import &repositories...", "reapack_manager_import"), ACTION_IMPORT_REPO);
+  menu.addAction(__LOCALIZE("Import &repositories...", "reapack_manager"), ACTION_IMPORT_REPO);
   menu.addSeparator();
-  menu.addAction(__LOCALIZE("Import offline archive...", "reapack_manager_import"), ACTION_IMPORT_ARCHIVE);
-  menu.addAction(__LOCALIZE("&Export offline archive...", "reapack_manager_import"), ACTION_EXPORT_ARCHIVE);
+  menu.addAction(__LOCALIZE("Import offline archive...", "reapack_manager"), ACTION_IMPORT_ARCHIVE);
+  menu.addAction(__LOCALIZE("&Export offline archive...", "reapack_manager"), ACTION_EXPORT_ARCHIVE);
 
   menu.show(getControl(IDC_IMPORT), handle());
 }
@@ -494,7 +494,7 @@ bool Manager::importRepo()
 
 void Manager::importArchive()
 {
-  const char *title = __LOCALIZE("Import offline archive", "reapack_manager_import");
+  const char *title = __LOCALIZE("Import offline archive", "reapack_manager");
 
   const std::string &path = FileDialog::getOpenFileName(handle(), instance(),
     title, Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
@@ -507,7 +507,7 @@ void Manager::importArchive()
   }
   catch(const reapack_error &e) {
     Win32::messageBox(handle(), String::format(
-      __LOCALIZE("An error occured while reading %s.\n\n%s.", "reapack_manager_error_msg"), path.c_str(), e.what()
+      __LOCALIZE("An error occured while reading %s.\n\n%s.", "reapack_manager"), path.c_str(), e.what()
     ).c_str(), title, MB_OK);
   }
 }
@@ -515,7 +515,7 @@ void Manager::importArchive()
 void Manager::exportArchive()
 {
   const std::string &path = FileDialog::getSaveFileName(handle(), instance(),
-    __LOCALIZE("Export offline archive", "reapack_manager_error_msg"), Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
+    __LOCALIZE("Export offline archive", "reapack_manager"), Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
 
   if(!path.empty()) {
     if(Transaction *tx = g_reapack->setupTransaction()) {
@@ -528,7 +528,7 @@ void Manager::exportArchive()
 void Manager::launchBrowser()
 {
   const auto promptApply = [this] {
-    return IDYES == Win32::messageBox(handle(), __LOCALIZE("Apply unsaved changes?", "reapack_manager_msg"), __LOCALIZE("ReaPack Query", "reapack_manager_msg"), MB_YESNO);
+    return IDYES == Win32::messageBox(handle(), __LOCALIZE("Apply unsaved changes?", "reapack_manager"), __LOCALIZE("ReaPack Query", "reapack_manager"), MB_YESNO);
   };
 
   if(m_changes && promptApply())
@@ -542,30 +542,30 @@ void Manager::options()
   Menu menu;
 
   UINT index = menu.addAction(
-    __LOCALIZE("&Install new packages when synchronizing", "reapack_manager_menu"), ACTION_AUTOINSTALL);
+    __LOCALIZE("&Install new packages when synchronizing", "reapack_manager"), ACTION_AUTOINSTALL);
   if(m_autoInstall.value_or(g_reapack->config()->install.autoInstall))
     menu.check(index);
 
   index = menu.addAction(
-    __LOCALIZE("Enable &pre-releases globally (bleeding edge)", "reapack_manager_menu"), ACTION_BLEEDINGEDGE);
+    __LOCALIZE("Enable &pre-releases globally (bleeding edge)", "reapack_manager"), ACTION_BLEEDINGEDGE);
   if(m_bleedingEdge.value_or(g_reapack->config()->install.bleedingEdge))
     menu.check(index);
 
   index = menu.addAction(
-    __LOCALIZE("Prompt to uninstall obsolete packages", "reapack_manager_menu"), ACTION_PROMPTOBSOLETE);
+    __LOCALIZE("Prompt to uninstall obsolete packages", "reapack_manager"), ACTION_PROMPTOBSOLETE);
   if(m_promptObsolete.value_or(g_reapack->config()->install.promptObsolete))
     menu.check(index);
 
   index = menu.addAction(
-    __LOCALIZE("Search for synonyms of common words", "reapack_manager_menu"), ACTION_SYNONYMS);
+    __LOCALIZE("Search for synonyms of common words", "reapack_manager"), ACTION_SYNONYMS);
   if(m_expandSynonyms.value_or(g_reapack->config()->filter.expandSynonyms))
     menu.check(index);
 
-  menu.addAction(__LOCALIZE("&Network settings...", "reapack_manager_menu"), ACTION_NETCONFIG);
+  menu.addAction(__LOCALIZE("&Network settings...", "reapack_manager"), ACTION_NETCONFIG);
 
   menu.addSeparator();
 
-  menu.addAction(__LOCALIZE("&Restore default settings", "reapack_manager_menu"), ACTION_RESETCONFIG);
+  menu.addAction(__LOCALIZE("&Restore default settings", "reapack_manager"), ACTION_RESETCONFIG);
 
   menu.show(getControl(IDC_OPTIONS), handle());
 }
@@ -585,9 +585,9 @@ bool Manager::confirm() const
 
   return IDYES == Win32::messageBox(handle(), String::format(
     __LOCALIZE("Uninstall %zu %s?\n"
-    "Every file they contain will be removed from your computer.", "reapack_manager_msg"),
-    uninstallCount, uninstallCount == 1 ? __LOCALIZE("repository", "reapack_manager_menu") : __LOCALIZE("repositories", "reapack_manager_menu")
-  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_manager_menu"), MB_YESNO);
+    "Every file they contain will be removed from your computer.", "reapack_manager"),
+    uninstallCount, uninstallCount == 1 ? __LOCALIZE("repository", "reapack_manager") : __LOCALIZE("repositories", "reapack_manager")
+  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_manager"), MB_YESNO);
 }
 
 bool Manager::apply()

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -34,6 +34,8 @@
 
 #include <algorithm>
 
+#include <WDL/localize/localize.h>
+
 static const Win32::char_type *ARCHIVE_FILTER =
   L("ReaPack Offline Archive (*.ReaPackArchive)\0*.ReaPackArchive\0");
 static const Win32::char_type *ARCHIVE_EXT = L("ReaPackArchive");
@@ -67,8 +69,8 @@ void Manager::onInit()
   disable(m_apply);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {"Name", 155},
-    {"Index URL", 435},
+    {__LOCALIZE("Name", "reapack_manager_column"), 155},
+    {__LOCALIZE("Index URL", "reapack_manager_column"), 435},
   });
 
   m_list->enableIcons();
@@ -211,28 +213,28 @@ bool Manager::fillContextMenu(Menu &menu, const int index) const
   const Remote &remote = getRemote(index);
 
   if(!remote) {
-    menu.addAction("&Select all", ACTION_SELECT);
-    menu.addAction("&Unselect all", ACTION_UNSELECT);
+    menu.addAction(__LOCALIZE("&Select all", "reapack_manager_menu"), ACTION_SELECT);
+    menu.addAction(__LOCALIZE("&Unselect all", "reapack_manager_menu"), ACTION_UNSELECT);
     return true;
   }
 
-  menu.addAction("&Refresh", ACTION_REFRESH);
-  menu.addAction("&Copy URL", ACTION_COPYURL);
+  menu.addAction(__LOCALIZE("&Refresh", "reapack_manager_menu"), ACTION_REFRESH);
+  menu.addAction(__LOCALIZE("&Copy URL", "reapack_manager_menu"), ACTION_COPYURL);
 
-  Menu autoInstallMenu = menu.addMenu("&Install new packages");
+  Menu autoInstallMenu = menu.addMenu(__LOCALIZE("&Install new packages", "reapack_manager_menu"));
   const UINT autoInstallGlobal = autoInstallMenu.addAction(
-    "Use &global setting", ACTION_AUTOINSTALL_GLOBAL);
+    __LOCALIZE("Use &global setting", "reapack_manager_menu"), ACTION_AUTOINSTALL_GLOBAL);
   const UINT autoInstallOff = autoInstallMenu.addAction(
-    "Manually", ACTION_AUTOINSTALL_OFF);
+    __LOCALIZE("Manually", "reapack_manager_menu"), ACTION_AUTOINSTALL_OFF);
   const UINT autoInstallOn = autoInstallMenu.addAction(
-    "When synchronizing", ACTION_AUTOINSTALL_ON);
+    __LOCALIZE("When synchronizing", "reapack_manager_menu"), ACTION_AUTOINSTALL_ON);
 
   const UINT uninstallAction =
-    menu.addAction("&Uninstall", ACTION_UNINSTALL);
+    menu.addAction(__LOCALIZE("&Uninstall", "reapack_manager_menu"), ACTION_UNINSTALL);
 
   menu.addSeparator();
 
-  menu.addAction(String::format("&About %s", remote.name().c_str()),
+  menu.addAction(String::format(__LOCALIZE("&About %s", "reapack_manager_menu"), remote.name().c_str()),
     index | (ACTION_ABOUT << 8));
 
   bool allProtected = true;
@@ -470,10 +472,10 @@ void Manager::aboutRepo(const bool focus)
 void Manager::importExport()
 {
   Menu menu;
-  menu.addAction("Import &repositories...", ACTION_IMPORT_REPO);
+  menu.addAction(__LOCALIZE("Import &repositories...", "reapack_manager_import"), ACTION_IMPORT_REPO);
   menu.addSeparator();
-  menu.addAction("Import offline archive...", ACTION_IMPORT_ARCHIVE);
-  menu.addAction("&Export offline archive...", ACTION_EXPORT_ARCHIVE);
+  menu.addAction(__LOCALIZE("Import offline archive...", "reapack_manager_import"), ACTION_IMPORT_ARCHIVE);
+  menu.addAction(__LOCALIZE("&Export offline archive...", "reapack_manager_import"), ACTION_EXPORT_ARCHIVE);
 
   menu.show(getControl(IDC_IMPORT), handle());
 }
@@ -492,7 +494,7 @@ bool Manager::importRepo()
 
 void Manager::importArchive()
 {
-  const char *title = "Import offline archive";
+  const char *title = __LOCALIZE("Import offline archive", "reapack_manager_import");
 
   const std::string &path = FileDialog::getOpenFileName(handle(), instance(),
     title, Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
@@ -505,7 +507,7 @@ void Manager::importArchive()
   }
   catch(const reapack_error &e) {
     Win32::messageBox(handle(), String::format(
-      "An error occured while reading %s.\n\n%s.", path.c_str(), e.what()
+      __LOCALIZE("An error occured while reading %s.\n\n%s.", "reapack_manager_error_msg"), path.c_str(), e.what()
     ).c_str(), title, MB_OK);
   }
 }
@@ -513,7 +515,7 @@ void Manager::importArchive()
 void Manager::exportArchive()
 {
   const std::string &path = FileDialog::getSaveFileName(handle(), instance(),
-    "Export offline archive", Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
+    __LOCALIZE("Export offline archive", "reapack_manager_error_msg"), Path::DATA.prependRoot(), ARCHIVE_FILTER, ARCHIVE_EXT);
 
   if(!path.empty()) {
     if(Transaction *tx = g_reapack->setupTransaction()) {
@@ -526,7 +528,7 @@ void Manager::exportArchive()
 void Manager::launchBrowser()
 {
   const auto promptApply = [this] {
-    return IDYES == Win32::messageBox(handle(), "Apply unsaved changes?", "ReaPack Query", MB_YESNO);
+    return IDYES == Win32::messageBox(handle(), __LOCALIZE("Apply unsaved changes?", "reapack_manager_msg"), __LOCALIZE("ReaPack Query", "reapack_manager_msg"), MB_YESNO);
   };
 
   if(m_changes && promptApply())
@@ -540,30 +542,30 @@ void Manager::options()
   Menu menu;
 
   UINT index = menu.addAction(
-    "&Install new packages when synchronizing", ACTION_AUTOINSTALL);
+    __LOCALIZE("&Install new packages when synchronizing", "reapack_manager_menu"), ACTION_AUTOINSTALL);
   if(m_autoInstall.value_or(g_reapack->config()->install.autoInstall))
     menu.check(index);
 
   index = menu.addAction(
-    "Enable &pre-releases globally (bleeding edge)", ACTION_BLEEDINGEDGE);
+    __LOCALIZE("Enable &pre-releases globally (bleeding edge)", "reapack_manager_menu"), ACTION_BLEEDINGEDGE);
   if(m_bleedingEdge.value_or(g_reapack->config()->install.bleedingEdge))
     menu.check(index);
 
   index = menu.addAction(
-    "Prompt to uninstall obsolete packages", ACTION_PROMPTOBSOLETE);
+    __LOCALIZE("Prompt to uninstall obsolete packages", "reapack_manager_menu"), ACTION_PROMPTOBSOLETE);
   if(m_promptObsolete.value_or(g_reapack->config()->install.promptObsolete))
     menu.check(index);
 
   index = menu.addAction(
-    "Search for synonyms of common words", ACTION_SYNONYMS);
+    __LOCALIZE("Search for synonyms of common words", "reapack_manager_menu"), ACTION_SYNONYMS);
   if(m_expandSynonyms.value_or(g_reapack->config()->filter.expandSynonyms))
     menu.check(index);
 
-  menu.addAction("&Network settings...", ACTION_NETCONFIG);
+  menu.addAction(__LOCALIZE("&Network settings...", "reapack_manager_menu"), ACTION_NETCONFIG);
 
   menu.addSeparator();
 
-  menu.addAction("&Restore default settings", ACTION_RESETCONFIG);
+  menu.addAction(__LOCALIZE("&Restore default settings", "reapack_manager_menu"), ACTION_RESETCONFIG);
 
   menu.show(getControl(IDC_OPTIONS), handle());
 }
@@ -582,10 +584,10 @@ bool Manager::confirm() const
     return true;
 
   return IDYES == Win32::messageBox(handle(), String::format(
-    "Uninstall %zu %s?\n"
-    "Every file they contain will be removed from your computer.",
-    uninstallCount, uninstallCount == 1 ? "repository" : "repositories"
-  ).c_str(), "ReaPack Query", MB_YESNO);
+    __LOCALIZE("Uninstall %zu %s?\n"
+    "Every file they contain will be removed from your computer.", "reapack_manager_msg"),
+    uninstallCount, uninstallCount == 1 ? __LOCALIZE("repository", "reapack_manager_menu") : __LOCALIZE("repositories", "reapack_manager_menu")
+  ).c_str(), __LOCALIZE("ReaPack Query", "reapack_manager_menu"), MB_YESNO);
 }
 
 bool Manager::apply()

--- a/src/obsquery.cpp
+++ b/src/obsquery.cpp
@@ -23,6 +23,7 @@
 #include "resource.hpp"
 
 #include <sstream>
+#include <WDL/localize/localize.h>
 
 enum { ACTION_SELECT_ALL = 300, ACTION_UNSELECT_ALL };
 
@@ -39,13 +40,13 @@ void ObsoleteQuery::onInit()
   m_okBtn = getControl(IDOK);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {"Package", 550}
+    {__LOCALIZE("Package", "reapack_obsolete_column"), 550}
   });
 
   m_list->onSelect >> [=] { setEnabled(m_list->hasSelection(), m_okBtn); };
   m_list->onFillContextMenu >> [=] (Menu &menu, int) {
-    menu.addAction("Select &all", ACTION_SELECT_ALL);
-    menu.addAction("&Unselect all", ACTION_UNSELECT_ALL);
+    menu.addAction(__LOCALIZE("Select &all", "reapack_obsolete_menu"), ACTION_SELECT_ALL);
+    menu.addAction(__LOCALIZE("&Unselect all", "reapack_obsolete_menu"), ACTION_UNSELECT_ALL);
     return true;
   };
 

--- a/src/obsquery.cpp
+++ b/src/obsquery.cpp
@@ -40,13 +40,13 @@ void ObsoleteQuery::onInit()
   m_okBtn = getControl(IDOK);
 
   m_list = createControl<ListView>(IDC_LIST, ListView::Columns{
-    {__LOCALIZE("Package", "reapack_obsolete_column"), 550}
+    {__LOCALIZE("Package", "reapack_obsquery"), 550}
   });
 
   m_list->onSelect >> [=] { setEnabled(m_list->hasSelection(), m_okBtn); };
   m_list->onFillContextMenu >> [=] (Menu &menu, int) {
-    menu.addAction(__LOCALIZE("Select &all", "reapack_obsolete_menu"), ACTION_SELECT_ALL);
-    menu.addAction(__LOCALIZE("&Unselect all", "reapack_obsolete_menu"), ACTION_UNSELECT_ALL);
+    menu.addAction(__LOCALIZE("Select &all", "reapack_obsquery"), ACTION_SELECT_ALL);
+    menu.addAction(__LOCALIZE("&Unselect all", "reapack_obsquery"), ACTION_UNSELECT_ALL);
     return true;
   };
 

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -93,10 +93,10 @@ Package::Package(const Type type, const std::string &name, const Category *cat)
   : m_category(cat), m_type(type), m_name(name)
 {
   if(m_name.empty())
-    throw reapack_error(__LOCALIZE("empty package name", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("empty package name", "reapack_package"));
   else if(m_name.find_first_of("/\\") != std::string::npos) {
     throw reapack_error(
-      String::format(__LOCALIZE("invalid package name '%s'", "reapack_error_msg"), m_name.c_str()));
+      String::format(__LOCALIZE("invalid package name '%s'", "reapack_package"), m_name.c_str()));
   }
 }
 
@@ -118,7 +118,7 @@ bool Package::addVersion(const Version *ver)
   else if(ver->sources().empty())
     return false;
   else if(m_versions.count(ver)) {
-    throw reapack_error(String::format(__LOCALIZE("duplicate version '%s'", "reapack_error_msg"),
+    throw reapack_error(String::format(__LOCALIZE("duplicate version '%s'", "reapack_package"),
       ver->fullName().c_str()));
   }
 

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -19,6 +19,8 @@
 
 #include "errors.hpp"
 #include "index.hpp"
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <algorithm>
 #include <boost/range/adaptor/reversed.hpp>
@@ -91,10 +93,10 @@ Package::Package(const Type type, const std::string &name, const Category *cat)
   : m_category(cat), m_type(type), m_name(name)
 {
   if(m_name.empty())
-    throw reapack_error("empty package name");
+    throw reapack_error(__LOCALIZE("empty package name", "reapack_error_msg"));
   else if(m_name.find_first_of("/\\") != std::string::npos) {
     throw reapack_error(
-      String::format("invalid package name '%s'", m_name.c_str()));
+      String::format(__LOCALIZE("invalid package name '%s'", "reapack_error_msg"), m_name.c_str()));
   }
 }
 
@@ -116,7 +118,7 @@ bool Package::addVersion(const Version *ver)
   else if(ver->sources().empty())
     return false;
   else if(m_versions.count(ver)) {
-    throw reapack_error(String::format("duplicate version '%s'",
+    throw reapack_error(String::format(__LOCALIZE("duplicate version '%s'", "reapack_error_msg"),
       ver->fullName().c_str()));
   }
 

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -21,6 +21,7 @@
 #include "win32.hpp"
 
 #include <sstream>
+#include <WDL/localize/localize.h>
 
 Progress::Progress(ThreadPool *pool)
   : Dialog(IDD_PROGRESS_DIALOG),
@@ -86,7 +87,7 @@ void Progress::addTask(ThreadTask *task)
 
 void Progress::updateProgress()
 {
-  Win32::setWindowText(m_label, String::format("%s %s of %s: %s",
+  Win32::setWindowText(m_label, String::format(__LOCALIZE("%s %s of %s: %s", "reapack_progress"),
     m_current.step,
     String::number(std::min(m_done + 1, m_total)).c_str(),
     String::number(m_total).c_str(),
@@ -99,6 +100,6 @@ void Progress::updateProgress()
 
   SendMessage(m_progress, PBM_SETPOS, percent, 0);
   Win32::setWindowText(handle(), String::format(
-    "ReaPack: Operation in progress (%d%%)", percent
+    __LOCALIZE("ReaPack: Operation in progress (%d%%)", "reapack_progress"), percent
   ).c_str());
 }

--- a/src/reapack.cpp
+++ b/src/reapack.cpp
@@ -109,22 +109,22 @@ ReaPack::~ReaPack()
 
 void ReaPack::setupActions()
 {
-  m_actions.add("REAPACK_SYNC", __LOCALIZE("ReaPack: Synchronize packages", "reapack_actionlist"),
+  m_actions.add("REAPACK_SYNC", __LOCALIZE("ReaPack: Synchronize packages", "reapack_reapack"),
     std::bind(&ReaPack::synchronizeAll, this));
 
-  m_actions.add("REAPACK_BROWSE", __LOCALIZE("ReaPack: Browse packages...", "reapack_actionlist"),
+  m_actions.add("REAPACK_BROWSE", __LOCALIZE("ReaPack: Browse packages...", "reapack_reapack"),
     std::bind(&ReaPack::browsePackages, this));
 
-  m_actions.add("REAPACK_UPLOAD", __LOCALIZE("ReaPack: Package editor", "reapack_actionlist"),
+  m_actions.add("REAPACK_UPLOAD", __LOCALIZE("ReaPack: Package editor", "reapack_reapack"),
     std::bind(&ReaPack::uploadPackage, this));
 
-  m_actions.add("REAPACK_IMPORT", __LOCALIZE("ReaPack: Import repositories...", "reapack_actionlist"),
+  m_actions.add("REAPACK_IMPORT", __LOCALIZE("ReaPack: Import repositories...", "reapack_reapack"),
     std::bind(&ReaPack::importRemote, this));
 
-  m_actions.add("REAPACK_MANAGE", __LOCALIZE("ReaPack: Manage repositories...", "reapack_actionlist"),
+  m_actions.add("REAPACK_MANAGE", __LOCALIZE("ReaPack: Manage repositories...", "reapack_reapack"),
     std::bind(&ReaPack::manageRemotes, this));
 
-  m_actions.add("REAPACK_ABOUT", __LOCALIZE("ReaPack: About...", "reapack_actionlist"),
+  m_actions.add("REAPACK_ABOUT", __LOCALIZE("ReaPack: About...", "reapack_reapack"),
     std::bind(&ReaPack::aboutSelf, this));
 }
 
@@ -148,7 +148,7 @@ void ReaPack::synchronizeAll()
   const std::vector<Remote> &remotes = m_config.remotes.getEnabled();
 
   if(remotes.empty()) {
-    ShowMessageBox(__LOCALIZE("No repository enabled, nothing to do!", "reapack_error_msg"), __LOCALIZE("ReaPack", "reapack"), MB_OK);
+    ShowMessageBox(__LOCALIZE("No repository enabled, nothing to do!", "reapack_reapack"), __LOCALIZE("ReaPack", "reapack_reapack"), MB_OK);
     return;
   }
 
@@ -242,7 +242,7 @@ void ReaPack::about(const Remote &repo, const bool focus)
 
 void ReaPack::aboutSelf()
 {
-  about(remote(__LOCALIZE("ReaPack", "reapack")));
+  about(remote(__LOCALIZE("ReaPack", "reapack_reapack")));
 }
 
 About *ReaPack::about(const bool instantiate)
@@ -284,9 +284,9 @@ Transaction *ReaPack::setupTransaction()
   }
   catch(const reapack_error &e) {
     Win32::messageBox(m_mainWindow, String::format(
-      __LOCALIZE("The following error occurred while creating a transaction:\n\n%s", "reapack_error_msg"),
+      __LOCALIZE("The following error occurred while creating a transaction:\n\n%s", "reapack_reapack"),
       e.what()
-    ).c_str(), __LOCALIZE("ReaPack", "reapack"), MB_OK);
+    ).c_str(), __LOCALIZE("ReaPack", "reapack_reapack"), MB_OK);
     return nullptr;
   }
 
@@ -351,8 +351,8 @@ bool ReaPack::requestProxy()
       "by GitHub will fail with a 429 error code)."
       "\r\n\r\n"
       "This setting can be changed at any time in "
-      "ReaPack > Manage repositories > Options > Network settings.", "reapack_error_msg"),
-      __LOCALIZE("ReaPack", "reapack"), MB_RETRYCANCEL | MB_ICONQUESTION);
+      "ReaPack > Manage repositories > Options > Network settings.", "reapack_reapack"),
+      __LOCALIZE("ReaPack", "reapack_reapack"), MB_RETRYCANCEL | MB_ICONQUESTION);
   }
 
   return static_cast<bool>(m_config.network.fallbackProxy);
@@ -399,9 +399,9 @@ void ReaPack::createDirectories()
   Win32::messageBox(Splash_GetWnd(), String::format(
     __LOCALIZE("ReaPack could not create %s! "
     "Please investigate or report this issue.\n\n"
-    "Error description: %s", "reapack_error_msg"),
+    "Error description: %s", "reapack_reapack"),
     path.prependRoot().join().c_str(), FS::lastError()
-  ).c_str(), __LOCALIZE("ReaPack", "reapack"), MB_OK);
+  ).c_str(), __LOCALIZE("ReaPack", "reapack_reapack"), MB_OK);
 }
 
 void ReaPack::registerSelf()

--- a/src/reapack.cpp
+++ b/src/reapack.cpp
@@ -37,6 +37,8 @@
 
 #include <reaper_plugin_functions.h>
 
+#include <WDL/localize/localize.h>
+
 ReaPack *ReaPack::s_instance = nullptr;
 
 #ifdef _WIN32
@@ -107,22 +109,22 @@ ReaPack::~ReaPack()
 
 void ReaPack::setupActions()
 {
-  m_actions.add("REAPACK_SYNC", "ReaPack: Synchronize packages",
+  m_actions.add("REAPACK_SYNC", __LOCALIZE("ReaPack: Synchronize packages", "reapack_actionlist"),
     std::bind(&ReaPack::synchronizeAll, this));
 
-  m_actions.add("REAPACK_BROWSE", "ReaPack: Browse packages...",
+  m_actions.add("REAPACK_BROWSE", __LOCALIZE("ReaPack: Browse packages...", "reapack_actionlist"),
     std::bind(&ReaPack::browsePackages, this));
 
-  m_actions.add("REAPACK_UPLOAD", "ReaPack: Package editor",
+  m_actions.add("REAPACK_UPLOAD", __LOCALIZE("ReaPack: Package editor", "reapack_actionlist"),
     std::bind(&ReaPack::uploadPackage, this));
 
-  m_actions.add("REAPACK_IMPORT", "ReaPack: Import repositories...",
+  m_actions.add("REAPACK_IMPORT", __LOCALIZE("ReaPack: Import repositories...", "reapack_actionlist"),
     std::bind(&ReaPack::importRemote, this));
 
-  m_actions.add("REAPACK_MANAGE", "ReaPack: Manage repositories...",
+  m_actions.add("REAPACK_MANAGE", __LOCALIZE("ReaPack: Manage repositories...", "reapack_actionlist"),
     std::bind(&ReaPack::manageRemotes, this));
 
-  m_actions.add("REAPACK_ABOUT", "ReaPack: About...",
+  m_actions.add("REAPACK_ABOUT", __LOCALIZE("ReaPack: About...", "reapack_actionlist"),
     std::bind(&ReaPack::aboutSelf, this));
 }
 
@@ -146,7 +148,7 @@ void ReaPack::synchronizeAll()
   const std::vector<Remote> &remotes = m_config.remotes.getEnabled();
 
   if(remotes.empty()) {
-    ShowMessageBox("No repository enabled, nothing to do!", "ReaPack", MB_OK);
+    ShowMessageBox(__LOCALIZE("No repository enabled, nothing to do!", "reapack_error_msg"), __LOCALIZE("ReaPack", "reapack"), MB_OK);
     return;
   }
 
@@ -240,7 +242,7 @@ void ReaPack::about(const Remote &repo, const bool focus)
 
 void ReaPack::aboutSelf()
 {
-  about(remote("ReaPack"));
+  about(remote(__LOCALIZE("ReaPack", "reapack")));
 }
 
 About *ReaPack::about(const bool instantiate)
@@ -282,9 +284,9 @@ Transaction *ReaPack::setupTransaction()
   }
   catch(const reapack_error &e) {
     Win32::messageBox(m_mainWindow, String::format(
-      "The following error occurred while creating a transaction:\n\n%s",
+      __LOCALIZE("The following error occurred while creating a transaction:\n\n%s", "reapack_error_msg"),
       e.what()
-    ).c_str(), "ReaPack", MB_OK);
+    ).c_str(), __LOCALIZE("ReaPack", "reapack"), MB_OK);
     return nullptr;
   }
 
@@ -340,7 +342,7 @@ bool ReaPack::requestProxy()
     LockDialog progressLock(m_progress.get());
 
     m_config.network.fallbackProxy = IDRETRY == Win32::messageBox(m_mainWindow,
-      "GitHub has temporarily rate-limited file download requests from ReaPack."
+      __LOCALIZE("GitHub has temporarily rate-limited file download requests from ReaPack."
       "\r\n\r\n"
       "Click on Retry to authorize ReaPack to automatically download from "
       "reapack.com instead of directly from github.com when this occurs."
@@ -349,8 +351,8 @@ bool ReaPack::requestProxy()
       "by GitHub will fail with a 429 error code)."
       "\r\n\r\n"
       "This setting can be changed at any time in "
-      "ReaPack > Manage repositories > Options > Network settings.",
-      "ReaPack", MB_RETRYCANCEL | MB_ICONQUESTION);
+      "ReaPack > Manage repositories > Options > Network settings.", "reapack_error_msg"),
+      __LOCALIZE("ReaPack", "reapack"), MB_RETRYCANCEL | MB_ICONQUESTION);
   }
 
   return static_cast<bool>(m_config.network.fallbackProxy);
@@ -395,11 +397,11 @@ void ReaPack::createDirectories()
     return;
 
   Win32::messageBox(Splash_GetWnd(), String::format(
-    "ReaPack could not create %s! "
+    __LOCALIZE("ReaPack could not create %s! "
     "Please investigate or report this issue.\n\n"
-    "Error description: %s",
+    "Error description: %s", "reapack_error_msg"),
     path.prependRoot().join().c_str(), FS::lastError()
-  ).c_str(), "ReaPack", MB_OK);
+  ).c_str(), __LOCALIZE("ReaPack", "reapack"), MB_OK);
 }
 
 void ReaPack::registerSelf()

--- a/src/receipt.cpp
+++ b/src/receipt.cpp
@@ -69,22 +69,22 @@ void Receipt::addError(const ErrorInfo &err)
 
 ReceiptPage Receipt::installedPage() const
 {
-  return {m_installs, __LOCALIZE("Installed", "reapack_receipt_tab")};
+  return {m_installs, __LOCALIZE("Installed", "reapack_receipt")};
 }
 
 ReceiptPage Receipt::removedPage() const
 {
-  return {m_removals, __LOCALIZE("Removed", "reapack_receipt_tab")};
+  return {m_removals, __LOCALIZE("Removed", "reapack_receipt")};
 }
 
 ReceiptPage Receipt::exportedPage() const
 {
-  return {m_exports, __LOCALIZE("Exported", "reapack_receipt_tab")};
+  return {m_exports, __LOCALIZE("Exported", "reapack_receipt")};
 }
 
 ReceiptPage Receipt::errorPage() const
 {
-  return {m_errors, __LOCALIZE("Error", "reapack_receipt_tab"), __LOCALIZE("Errors", "reapack_receipt_tab")};
+  return {m_errors, __LOCALIZE("Error", "reapack_receipt"), __LOCALIZE("Errors", "reapack_receipt")};
 }
 
 void ReceiptPage::setTitle(const char *title)

--- a/src/receipt.cpp
+++ b/src/receipt.cpp
@@ -23,6 +23,9 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include <sstream>
 
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
+
 Receipt::Receipt()
   : m_flags(NoFlag)
 {
@@ -66,22 +69,22 @@ void Receipt::addError(const ErrorInfo &err)
 
 ReceiptPage Receipt::installedPage() const
 {
-  return {m_installs, "Installed"};
+  return {m_installs, __LOCALIZE("Installed", "reapack_receipt_tab")};
 }
 
 ReceiptPage Receipt::removedPage() const
 {
-  return {m_removals, "Removed"};
+  return {m_removals, __LOCALIZE("Removed", "reapack_receipt_tab")};
 }
 
 ReceiptPage Receipt::exportedPage() const
 {
-  return {m_exports, "Exported"};
+  return {m_exports, __LOCALIZE("Exported", "reapack_receipt_tab")};
 }
 
 ReceiptPage Receipt::errorPage() const
 {
-  return {m_errors, "Error", "Errors"};
+  return {m_errors, __LOCALIZE("Error", "reapack_receipt_tab"), __LOCALIZE("Errors", "reapack_receipt_tab")};
 }
 
 void ReceiptPage::setTitle(const char *title)

--- a/src/remote.cpp
+++ b/src/remote.cpp
@@ -106,9 +106,9 @@ Remote::Remote(const std::string &name, const std::string &url,
 void Remote::setName(const std::string &name)
 {
   if(name.empty())
-    throw reapack_error(__LOCALIZE("empty repository name", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("empty repository name", "reapack_remote"));
   if(!validateName(name)) // also checks for emptyness
-    throw reapack_error(String::format(__LOCALIZE("invalid repository name '%s'", "reapack_error_msg"), name.c_str()));
+    throw reapack_error(String::format(__LOCALIZE("invalid repository name '%s'", "reapack_remote"), name.c_str()));
 
   m_name = name;
 }
@@ -116,9 +116,9 @@ void Remote::setName(const std::string &name)
 void Remote::setUrl(const std::string &url)
 {
   if(!validateUrl(url))
-    throw reapack_error(__LOCALIZE("invalid url", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("invalid url", "reapack_remote"));
   else if(m_protected && url != m_url)
-    throw reapack_error(__LOCALIZE("cannot change the URL of a protected repository", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("cannot change the URL of a protected repository", "reapack_remote"));
 
   m_url = url;
 }

--- a/src/remote.cpp
+++ b/src/remote.cpp
@@ -18,6 +18,8 @@
 #include "remote.hpp"
 
 #include "errors.hpp"
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/logic/tribool_io.hpp>
@@ -104,9 +106,9 @@ Remote::Remote(const std::string &name, const std::string &url,
 void Remote::setName(const std::string &name)
 {
   if(name.empty())
-    throw reapack_error("empty repository name");
+    throw reapack_error(__LOCALIZE("empty repository name", "reapack_error_msg"));
   if(!validateName(name)) // also checks for emptyness
-    throw reapack_error(String::format("invalid repository name '%s'", name.c_str()));
+    throw reapack_error(String::format(__LOCALIZE("invalid repository name '%s'", "reapack_error_msg"), name.c_str()));
 
   m_name = name;
 }
@@ -114,9 +116,9 @@ void Remote::setName(const std::string &name)
 void Remote::setUrl(const std::string &url)
 {
   if(!validateUrl(url))
-    throw reapack_error("invalid url");
+    throw reapack_error(__LOCALIZE("invalid url", "reapack_error_msg"));
   else if(m_protected && url != m_url)
-    throw reapack_error("cannot change the URL of a protected repository");
+    throw reapack_error(__LOCALIZE("cannot change the URL of a protected repository", "reapack_error_msg"));
 
   m_url = url;
 }

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -22,6 +22,8 @@
 #include "tabbar.hpp"
 #include "win32.hpp"
 
+#include <WDL/localize/localize.h>
+
 Report::Report(const Receipt *receipt)
   : Dialog(IDD_REPORT_DIALOG), m_receipt(receipt), m_empty(true)
 {
@@ -59,8 +61,8 @@ void Report::onTimer(int timer)
   stopTimer(timer);
 
   Win32::messageBox(handle(),
-    "One or more native REAPER extensions were installed.\n"
-    "These newly installed files won't be loaded until REAPER is restarted.",
+    __LOCALIZE("One or more native REAPER extensions were installed.\n"
+    "These newly installed files won't be loaded until REAPER is restarted.", "reapack_report_msg"),
     "ReaPack Notice", MB_OK);
 }
 
@@ -69,13 +71,13 @@ void Report::updateLabel()
   const char *label;
 
   if(m_receipt->flags() == Receipt::ErrorFlag)
-    label = "Operation failed. The following error(s) occured:";
+    label = __LOCALIZE("Operation failed. The following error(s) occured:", "reapack_report_msg");
   else if(m_receipt->test(Receipt::ErrorFlag))
-    label = "The operation was partially completed (one or more errors occured):";
+    label = __LOCALIZE("The operation was partially completed (one or more errors occured):", "reapack_report_msg");
   else if(m_receipt->test(Receipt::InstalledOrRemoved))
-    label = "All done! Description of the changes:";
+    label = __LOCALIZE("All done! Description of the changes:", "reapack_report_msg");
   else
-    label = "Operation completed successfully!";
+    label = __LOCALIZE("Operation completed successfully!", "reapack_report_msg");
 
   Win32::setWindowText(getControl(IDC_LABEL), label);
 }

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -62,7 +62,7 @@ void Report::onTimer(int timer)
 
   Win32::messageBox(handle(),
     __LOCALIZE("One or more native REAPER extensions were installed.\n"
-    "These newly installed files won't be loaded until REAPER is restarted.", "reapack_report_msg"),
+    "These newly installed files won't be loaded until REAPER is restarted.", "reapack_report"),
     "ReaPack Notice", MB_OK);
 }
 
@@ -71,13 +71,13 @@ void Report::updateLabel()
   const char *label;
 
   if(m_receipt->flags() == Receipt::ErrorFlag)
-    label = __LOCALIZE("Operation failed. The following error(s) occured:", "reapack_report_msg");
+    label = __LOCALIZE("Operation failed. The following error(s) occured:", "reapack_report");
   else if(m_receipt->test(Receipt::ErrorFlag))
-    label = __LOCALIZE("The operation was partially completed (one or more errors occured):", "reapack_report_msg");
+    label = __LOCALIZE("The operation was partially completed (one or more errors occured):", "reapack_report");
   else if(m_receipt->test(Receipt::InstalledOrRemoved))
-    label = __LOCALIZE("All done! Description of the changes:", "reapack_report_msg");
+    label = __LOCALIZE("All done! Description of the changes:", "reapack_report");
   else
-    label = __LOCALIZE("Operation completed successfully!", "reapack_report_msg");
+    label = __LOCALIZE("Operation completed successfully!", "reapack_report");
 
   Win32::setWindowText(getControl(IDC_LABEL), label);
 }

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -19,6 +19,8 @@
 
 #include "errors.hpp"
 #include "index.hpp"
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <boost/algorithm/string/case_conv.hpp>
 
@@ -60,7 +62,7 @@ Source::Source(const std::string &file, const std::string &url, const Version *v
     m_version(ver)
 {
   if(m_url.empty())
-    throw reapack_error("empty source url");
+    throw reapack_error(__LOCALIZE("empty source url", "reapack_error_msg"));
 }
 
 Package::Type Source::type() const

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -62,7 +62,7 @@ Source::Source(const std::string &file, const std::string &url, const Version *v
     m_version(ver)
 {
   if(m_url.empty())
-    throw reapack_error(__LOCALIZE("empty source url", "reapack_error_msg"));
+    throw reapack_error(__LOCALIZE("empty source url", "reapack_source"));
 }
 
 Package::Type Source::type() const

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -26,6 +26,8 @@
 #include "remote.hpp"
 #include "task.hpp"
 
+#include <WDL/localize/localize.h>
+
 #include <cassert>
 
 #include <reaper_plugin_functions.h>
@@ -95,7 +97,7 @@ IndexPtr Transaction::loadIndex(const Remote &remote)
   }
   catch(const reapack_error &e) {
     m_receipt.addError({
-      String::format("Could not load repository: %s", e.what()), remote.name()});
+      String::format(__LOCALIZE("Could not load repository: %s", "reapack_error_msg"), e.what()), remote.name()});
     return nullptr;
   }
 }
@@ -276,7 +278,7 @@ void Transaction::registerScript(const HostTicket &reg, const bool isLastCall)
       isLastCall && isLastSection);
 
     if(!id && enableError) {
-      m_receipt.addError({"This script could not be registered in REAPER.",
+      m_receipt.addError({__LOCALIZE("This script could not be registered in REAPER.", "reapack_error_msg"),
         reg.file.path.join()});
       enableError = false;
     }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -97,7 +97,7 @@ IndexPtr Transaction::loadIndex(const Remote &remote)
   }
   catch(const reapack_error &e) {
     m_receipt.addError({
-      String::format(__LOCALIZE("Could not load repository: %s", "reapack_error_msg"), e.what()), remote.name()});
+      String::format(__LOCALIZE("Could not load repository: %s", "reapack_transaction"), e.what()), remote.name()});
     return nullptr;
   }
 }
@@ -278,7 +278,7 @@ void Transaction::registerScript(const HostTicket &reg, const bool isLastCall)
       isLastCall && isLastSection);
 
     if(!id && enableError) {
-      m_receipt.addError({__LOCALIZE("This script could not be registered in REAPER.", "reapack_error_msg"),
+      m_receipt.addError({__LOCALIZE("This script could not be registered in REAPER.", "reapack_transaction"),
         reg.file.path.join()});
       enableError = false;
     }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -20,6 +20,8 @@
 #include "errors.hpp"
 #include "package.hpp"
 #include "source.hpp"
+#include "win32.hpp"
+#include <WDL/localize/localize.h>
 
 #include <boost/lexical_cast.hpp>
 #include <cctype>
@@ -84,7 +86,7 @@ std::ostream &operator<<(std::ostream &os, const Version &ver)
   os << "\r\n";
 
   const std::string &changelog = ver.changelog();
-  os << String::indent(changelog.empty() ? "No changelog" : changelog);
+  os << String::indent(changelog.empty() ? __LOCALIZE("No changelog", "reapack") : changelog);
 
   return os;
 }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -86,7 +86,7 @@ std::ostream &operator<<(std::ostream &os, const Version &ver)
   os << "\r\n";
 
   const std::string &changelog = ver.changelog();
-  os << String::indent(changelog.empty() ? __LOCALIZE("No changelog", "reapack") : changelog);
+  os << String::indent(changelog.empty() ? __LOCALIZE("No changelog", "reapack_version") : changelog);
 
   return os;
 }


### PR DESCRIPTION
## Implementation Details

1. **Added buildlangpack.cpp**  
   - Most code sourced from the file of the same name in SWS
   - Used to create the `buildlangpack` binary
   - Compilation command:  
     ```bash
     cmake --build build --target buildlangpack
     ```
   - Usage command (also provided in comments):  
     ```bash
     buildlangpack --template src/*.cpp src/*.rc > ReaPack_template.ReaperLangPack
     ```
      Result file(ZIP): [ReaPack_ReaperLangPack_template.zip](https://github.com/user-attachments/files/22039272/ReaPack_ReaperLangPack_template.zip)


2. **Added Localization Support**  
   - Added `__LOCALIZE` macro to cpp files requiring localization

If you spot any errors or have suggestions for improvement, please feel free to make edits or point them out!

## Attachments
- Translated language pack reference files
   Please change the file extension from `.txt` to `.ReaperLangPack`.(Due to GitHub's upload restrictions on file extensions.)  
  [ReaPack_zh_CN.txt](https://github.com/user-attachments/files/22037317/ReaPack_zh_CN.txt)

- Effect screenshots demonstrating the implementation
  <img width="1559" height="935" alt="粘贴的图像 (4)" src="https://github.com/user-attachments/assets/f2032735-d34a-413f-b2b7-54566ed5c136" />

## Tested

- Archlinux x86_64
- Windows 11
