### PR TITLE
Replace calls to sprintf with snprintf.

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -85,7 +85,7 @@ void Database::setVersion(const Version &version)
   int32_t value = version.minor | static_cast<int32_t>(version.major) << 16;
 
   char sql[255];
-  snprintf(sql, 255, "PRAGMA user_version = %" PRId32, value);
+  snprintf(sql, sizeof(sql), "PRAGMA user_version = %" PRId32, value);
   exec(sql);
 }
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -85,7 +85,7 @@ void Database::setVersion(const Version &version)
   int32_t value = version.minor | static_cast<int32_t>(version.major) << 16;
 
   char sql[255];
-  sprintf(sql, "PRAGMA user_version = %" PRId32, value);
+  snprintf(sql, 255, "PRAGMA user_version = %" PRId32, value);
   exec(sql);
 }
 
@@ -110,7 +110,7 @@ void Database::commit()
 void Database::savepoint()
 {
   char sql[64];
-  sprintf(sql, "SAVEPOINT sp%zu", m_savePoint++);
+  snprintf(sql, sizeof(sql), "SAVEPOINT sp%zu", m_savePoint++);
 
   exec(sql);
 }
@@ -118,7 +118,7 @@ void Database::savepoint()
 void Database::restore()
 {
   char sql[64];
-  sprintf(sql, "ROLLBACK TO SAVEPOINT sp%zu", --m_savePoint);
+  snprintf(sql, sizeof(sql), "ROLLBACK TO SAVEPOINT sp%zu", --m_savePoint);
 
   exec(sql);
 }
@@ -126,7 +126,7 @@ void Database::restore()
 void Database::release()
 {
   char sql[64];
-  sprintf(sql, "RELEASE SAVEPOINT sp%zu", --m_savePoint);
+  snprintf(sql, sizeof(sql), "RELEASE SAVEPOINT sp%zu", --m_savePoint);
 
   exec(sql);
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -297,11 +297,11 @@ const std::string &Hash::digest()
 
   m_value.resize(multihash.size() * 2);
 
+  static const char hex[] = "0123456789abcdef";
+
   for(size_t i = 0; i < multihash.size(); ++i) {
-      char buf[3];
-      snprintf(buf, sizeof(buf), "%02x", multihash[i]);
-      m_value[i * 2] = buf[0];
-      m_value[i * 2 + 1] = buf[1];
+    m_value[i * 2] = hex[multihash[i] >> 4];
+    m_value[i * 2 + 1] = hex[multihash[i] & 0xf];
   }
 
   return m_value;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -297,8 +297,12 @@ const std::string &Hash::digest()
 
   m_value.resize(multihash.size() * 2);
 
-  for(size_t i = 0; i < multihash.size(); ++i)
-    sprintf(&m_value[i * 2], "%02x", multihash[i]);
+  for(size_t i = 0; i < multihash.size(); ++i) {
+      char buf[3];
+      snprintf(buf, sizeof(buf), "%02x", multihash[i]);
+      m_value[i * 2] = buf[0];
+      m_value[i * 2 + 1] = buf[1];
+  }
 
   return m_value;
 }


### PR DESCRIPTION
sprintf is now deprecated for security reasons. I.e. reapack did not build for me in a straight up MacOS setup and this PR fixes that.

There are no bugs fixed here though it does get rid of the distasteful practice of writing to the nul at the end of a `std::string` buffer.